### PR TITLE
Enemy Health and Player Projectile Collision

### DIFF
--- a/Sparrow/Assets/Prefabs/Cannonball.prefab
+++ b/Sparrow/Assets/Prefabs/Cannonball.prefab
@@ -15,7 +15,7 @@ GameObject:
   - component: {fileID: 4372930403595334076}
   m_Layer: 7
   m_Name: Cannonball
-  m_TagString: Untagged
+  m_TagString: PlayerAttack
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
@@ -158,7 +158,7 @@ CircleCollider2D:
   m_CallbackLayers:
     serializedVersion: 2
     m_Bits: 4294967295
-  m_IsTrigger: 1
+  m_IsTrigger: 0
   m_UsedByEffector: 0
   m_UsedByComposite: 0
   m_Offset: {x: 0, y: 0}

--- a/Sparrow/Assets/Prefabs/EnemyOrb.prefab
+++ b/Sparrow/Assets/Prefabs/EnemyOrb.prefab
@@ -16,7 +16,7 @@ GameObject:
   - component: {fileID: 2838014572800479170}
   m_Layer: 9
   m_Name: EnemyOrb
-  m_TagString: Untagged
+  m_TagString: EnemyAttack
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0

--- a/Sparrow/Assets/Prefabs/EnemyShipTEST1-Sheet(Mast).prefab
+++ b/Sparrow/Assets/Prefabs/EnemyShipTEST1-Sheet(Mast).prefab
@@ -13,6 +13,7 @@ GameObject:
   - component: {fileID: 4332703334164343706}
   - component: {fileID: -6183314917113772691}
   - component: {fileID: 605418080969120408}
+  - component: {fileID: 974075676751969829}
   m_Layer: 8
   m_Name: EnemyShipTEST1-Sheet(Mast)
   m_TagString: Enemy
@@ -95,7 +96,7 @@ Rigidbody2D:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1739139097824912367}
-  m_BodyType: 0
+  m_BodyType: 1
   m_Simulated: 1
   m_UseFullKinematicContacts: 0
   m_UseAutoMass: 0
@@ -162,3 +163,16 @@ CapsuleCollider2D:
   m_Offset: {x: 0, y: -0.051427245}
   m_Size: {x: 0.5371456, y: 0.95429444}
   m_Direction: 0
+--- !u!114 &974075676751969829
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1739139097824912367}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 18a9049f58596d741951f3caafddfaf7, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  HitPoints: 5

--- a/Sparrow/Assets/Prefabs/PlayerShipBase.prefab
+++ b/Sparrow/Assets/Prefabs/PlayerShipBase.prefab
@@ -139,6 +139,7 @@ GameObject:
   - component: {fileID: 9223001490044897287}
   - component: {fileID: -5228896584721120679}
   - component: {fileID: -7025868003506739830}
+  - component: {fileID: 3332890461431351674}
   m_Layer: 6
   m_Name: PlayerShipBase
   m_TagString: Player
@@ -371,6 +372,20 @@ CircleCollider2D:
   m_Offset: {x: 0, y: 0}
   serializedVersion: 2
   m_Radius: 0.8
+--- !u!114 &3332890461431351674
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6847842634037359419}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: bac8a4e0da2892e46a55a12b78969ec8, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  shipConfig: {fileID: 9223001490044897287}
+  target: {fileID: 0}
 --- !u!1 &7597696367023192810
 GameObject:
   m_ObjectHideFlags: 0

--- a/Sparrow/Assets/Scenes/Demo1.unity
+++ b/Sparrow/Assets/Scenes/Demo1.unity
@@ -151,7 +151,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: a0aaf447f802e28438e100555c09b523, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  characterPrefab: {fileID: 3632393490432388215, guid: 15c264c0908fd0d48923f56bafceced3, type: 3}
+  characterPrefab: {fileID: 6847842634037359419, guid: 9e7965dd074dd0a4abcb3864277b5d27, type: 3}
 --- !u!4 &642829876
 Transform:
   m_ObjectHideFlags: 0
@@ -343,7 +343,7 @@ MonoBehaviour:
   prefabWater: {fileID: 8979340069536578346, guid: 09b108a04595b6540b97fc1ed5afdd6b, type: 3}
   prefabSand: {fileID: 5896505433429229737, guid: f2f0ec9b45559d54fb267a5477aefb2a, type: 3}
   prefabGrass: {fileID: 2594190323953209280, guid: 7f5f5de2ecec21c489b5d7f05fd28042, type: 3}
-  player: {fileID: 3632393490432388215, guid: 15c264c0908fd0d48923f56bafceced3, type: 3}
+  player: {fileID: 6847842634037359419, guid: 9e7965dd074dd0a4abcb3864277b5d27, type: 3}
   enemyPrefab: {fileID: 1739139097824912367, guid: e6705a9387e6dc540b52c0d10860a8db, type: 3}
   numberOfEnemies: 5
   enemySpawnRadius: 5

--- a/Sparrow/Assets/Scenes/FiringTest.unity
+++ b/Sparrow/Assets/Scenes/FiringTest.unity
@@ -122,7 +122,7 @@ NavMeshSettings:
     debug:
       m_Flags: 0
   m_NavMeshData: {fileID: 0}
---- !u!1001 &19612101
+--- !u!1001 &941754628
 PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
@@ -133,26 +133,6 @@ PrefabInstance:
     - target: {fileID: -7025868003506739830, guid: 9e7965dd074dd0a4abcb3864277b5d27, type: 3}
       propertyPath: m_ExcludeLayers.m_Bits
       value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: -7025868003506739830, guid: 9e7965dd074dd0a4abcb3864277b5d27, type: 3}
-      propertyPath: m_IncludeLayers.m_Bits
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: -7025868003506739830, guid: 9e7965dd074dd0a4abcb3864277b5d27, type: 3}
-      propertyPath: m_LayerOverridePriority
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1279858412334187348, guid: 9e7965dd074dd0a4abcb3864277b5d27, type: 3}
-      propertyPath: m_Layer
-      value: 2
-      objectReference: {fileID: 0}
-    - target: {fileID: 1665600918682020118, guid: 9e7965dd074dd0a4abcb3864277b5d27, type: 3}
-      propertyPath: m_Layer
-      value: 2
-      objectReference: {fileID: 0}
-    - target: {fileID: 2776254383517004704, guid: 9e7965dd074dd0a4abcb3864277b5d27, type: 3}
-      propertyPath: m_Layer
-      value: 2
       objectReference: {fileID: 0}
     - target: {fileID: 3558335276874133501, guid: 9e7965dd074dd0a4abcb3864277b5d27, type: 3}
       propertyPath: m_LocalPosition.x
@@ -194,104 +174,15 @@ PrefabInstance:
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 4098763210983959559, guid: 9e7965dd074dd0a4abcb3864277b5d27, type: 3}
-      propertyPath: m_Layer
-      value: 2
-      objectReference: {fileID: 0}
     - target: {fileID: 6847842634037359419, guid: 9e7965dd074dd0a4abcb3864277b5d27, type: 3}
       propertyPath: m_Name
       value: PlayerShipBase
-      objectReference: {fileID: 0}
-    - target: {fileID: 6847842634037359419, guid: 9e7965dd074dd0a4abcb3864277b5d27, type: 3}
-      propertyPath: m_Layer
-      value: 2
-      objectReference: {fileID: 0}
-    - target: {fileID: 7597696367023192810, guid: 9e7965dd074dd0a4abcb3864277b5d27, type: 3}
-      propertyPath: m_Layer
-      value: 2
-      objectReference: {fileID: 0}
-    - target: {fileID: 8211575455811548723, guid: 9e7965dd074dd0a4abcb3864277b5d27, type: 3}
-      propertyPath: m_Layer
-      value: 2
-      objectReference: {fileID: 0}
-    - target: {fileID: 9223001490044897287, guid: 9e7965dd074dd0a4abcb3864277b5d27, type: 3}
-      propertyPath: cannonDefs.Array.data[0]
-      value: 
-      objectReference: {fileID: 11400000, guid: d8ed48c2720aaa64d8e7a6961abaafca, type: 2}
-    - target: {fileID: 9223001490044897287, guid: 9e7965dd074dd0a4abcb3864277b5d27, type: 3}
-      propertyPath: cannonDefs.Array.data[5]
-      value: 
       objectReference: {fileID: 0}
     m_RemovedComponents: []
     m_RemovedGameObjects: []
     m_AddedGameObjects: []
     m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 9e7965dd074dd0a4abcb3864277b5d27, type: 3}
---- !u!1001 &584095356
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    serializedVersion: 3
-    m_TransformParent: {fileID: 0}
-    m_Modifications:
-    - target: {fileID: -6183314917113772691, guid: e6705a9387e6dc540b52c0d10860a8db, type: 3}
-      propertyPath: m_Enabled
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 1739139097824912367, guid: e6705a9387e6dc540b52c0d10860a8db, type: 3}
-      propertyPath: m_Name
-      value: EnemyShipTEST1-Sheet(Mast)
-      objectReference: {fileID: 0}
-    - target: {fileID: 1739139097824912367, guid: e6705a9387e6dc540b52c0d10860a8db, type: 3}
-      propertyPath: m_Layer
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2803948586991084623, guid: e6705a9387e6dc540b52c0d10860a8db, type: 3}
-      propertyPath: m_LocalPosition.x
-      value: -0.021673024
-      objectReference: {fileID: 0}
-    - target: {fileID: 2803948586991084623, guid: e6705a9387e6dc540b52c0d10860a8db, type: 3}
-      propertyPath: m_LocalPosition.y
-      value: 1.5387661
-      objectReference: {fileID: 0}
-    - target: {fileID: 2803948586991084623, guid: e6705a9387e6dc540b52c0d10860a8db, type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2803948586991084623, guid: e6705a9387e6dc540b52c0d10860a8db, type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 2803948586991084623, guid: e6705a9387e6dc540b52c0d10860a8db, type: 3}
-      propertyPath: m_LocalRotation.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2803948586991084623, guid: e6705a9387e6dc540b52c0d10860a8db, type: 3}
-      propertyPath: m_LocalRotation.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2803948586991084623, guid: e6705a9387e6dc540b52c0d10860a8db, type: 3}
-      propertyPath: m_LocalRotation.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2803948586991084623, guid: e6705a9387e6dc540b52c0d10860a8db, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2803948586991084623, guid: e6705a9387e6dc540b52c0d10860a8db, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2803948586991084623, guid: e6705a9387e6dc540b52c0d10860a8db, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-    m_RemovedGameObjects: []
-    m_AddedGameObjects: []
-    m_AddedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: e6705a9387e6dc540b52c0d10860a8db, type: 3}
 --- !u!1 &1717913340
 GameObject:
   m_ObjectHideFlags: 0
@@ -384,10 +275,67 @@ Transform:
   m_Children: []
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1001 &1942092887
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 1739139097824912367, guid: e6705a9387e6dc540b52c0d10860a8db, type: 3}
+      propertyPath: m_Name
+      value: EnemyShipTEST1-Sheet(Mast)
+      objectReference: {fileID: 0}
+    - target: {fileID: 2803948586991084623, guid: e6705a9387e6dc540b52c0d10860a8db, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0.02
+      objectReference: {fileID: 0}
+    - target: {fileID: 2803948586991084623, guid: e6705a9387e6dc540b52c0d10860a8db, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 1.42
+      objectReference: {fileID: 0}
+    - target: {fileID: 2803948586991084623, guid: e6705a9387e6dc540b52c0d10860a8db, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2803948586991084623, guid: e6705a9387e6dc540b52c0d10860a8db, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 2803948586991084623, guid: e6705a9387e6dc540b52c0d10860a8db, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2803948586991084623, guid: e6705a9387e6dc540b52c0d10860a8db, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2803948586991084623, guid: e6705a9387e6dc540b52c0d10860a8db, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2803948586991084623, guid: e6705a9387e6dc540b52c0d10860a8db, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2803948586991084623, guid: e6705a9387e6dc540b52c0d10860a8db, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2803948586991084623, guid: e6705a9387e6dc540b52c0d10860a8db, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: e6705a9387e6dc540b52c0d10860a8db, type: 3}
 --- !u!1660057539 &9223372036854775807
 SceneRoots:
   m_ObjectHideFlags: 0
   m_Roots:
   - {fileID: 1717913343}
-  - {fileID: 19612101}
-  - {fileID: 584095356}
+  - {fileID: 941754628}
+  - {fileID: 1942092887}

--- a/Sparrow/Assets/Scripts/Cannons/CannonContainer.cs
+++ b/Sparrow/Assets/Scripts/Cannons/CannonContainer.cs
@@ -35,12 +35,12 @@ public class CannonContainer : MonoBehaviour
         CannonballLogic projectileConfig = projectile.GetComponent<CannonballLogic>();
         projectileConfig.maxDistance = cannonDef.attackDistance;
         projectileConfig.projectileSpeed = cannonDef.projectileSpeed;
+        projectileConfig.attackStrength = cannonDef.attackStrength;
 
         // Pass whatever additional references are needed by the cannon state machine
         CannonStateMachine _sm = cannon.GetComponent<CannonStateMachine>();
         _sm.projectile = projectile;
         _sm.projectileConfig = projectile.GetComponent<CannonballLogic>();
-        // _sm.CannonDef = cannonDef;
         _sm.CannonAnim = _cannonAnimator;
         _sm.CannonRb = cannon.GetComponent<Rigidbody2D>();
         _sm.ShipRb = shipRb;

--- a/Sparrow/Assets/Scripts/Cannons/CannonballLogic.cs
+++ b/Sparrow/Assets/Scripts/Cannons/CannonballLogic.cs
@@ -4,7 +4,7 @@ public class CannonballLogic : MonoBehaviour
 {
 
     public float maxDistance;
-
+    public int attackStrength;
     public Vector3 projectileSpawnPoint;
     public float projectileSpeed;
 
@@ -18,6 +18,14 @@ public class CannonballLogic : MonoBehaviour
     {
         Vector3 _distance = projectileSpawnPoint - transform.position;
         if (maxDistance < Mathf.Abs(_distance.magnitude))
+        {
+            Destroy(gameObject);
+        }
+    }
+
+    void OnCollisionEnter2D(Collision2D other){
+        // Check if we hit something (land, enemy) that would cause us to explode
+        if (other.gameObject.CompareTag("Enemy"))
         {
             Destroy(gameObject);
         }

--- a/Sparrow/Assets/Scripts/Enemies/EnemyHealthManager.cs
+++ b/Sparrow/Assets/Scripts/Enemies/EnemyHealthManager.cs
@@ -1,0 +1,20 @@
+using UnityEngine;
+
+public class EnemyHealthManager : MonoBehaviour
+{
+    public int HitPoints = 5;
+
+    void OnCollisionEnter2D(Collision2D other)
+    {
+        if (other.gameObject.CompareTag("PlayerAttack"))
+        {   
+            // This won't work if we have other non-projectile attack types
+            int damage = other.gameObject.GetComponent<CannonballLogic>().attackStrength;
+            HitPoints -= damage;
+        }
+        if (HitPoints <= 0)
+        {
+            Destroy(gameObject);
+        }
+    }
+}

--- a/Sparrow/Assets/Scripts/Enemies/EnemyHealthManager.cs.meta
+++ b/Sparrow/Assets/Scripts/Enemies/EnemyHealthManager.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 18a9049f58596d741951f3caafddfaf7
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Sparrow/Assets/Scripts/Player/ShipConfiguration.cs
+++ b/Sparrow/Assets/Scripts/Player/ShipConfiguration.cs
@@ -9,9 +9,6 @@ public class ShipConfiguration : MonoBehaviour
     public GameObject cannonTemplate;
     public Rigidbody2D shipRb;
     private List<GameObject> _cannons = new();
-    private GameObject _target = null;
-    private bool _targetWasClicked = false;
-    private string ENEMY_TAG = "Enemy";
 
     // Start is called before the first frame update
     void Start()
@@ -39,60 +36,12 @@ public class ShipConfiguration : MonoBehaviour
         _autoTargetCollider.radius = _maxDistance - 0.05f; // a little wiggle room so that we don't auto-target things just on the edge of range
     }
     
-    void Update()
+    public void UpdateTarget(GameObject target)
     {
-        if (Input.GetMouseButtonDown(0) && !PauseMenu.GameIsPaused)
-        {
-            SetTargetOnMouseClick();
-        }
-    }
-
-    void SetTargetOnMouseClick()
-    {
-        LayerMask enemyLayers = LayerMask.GetMask("Enemy");
-        Ray ray = Camera.main.ScreenPointToRay(Input.mousePosition);
-        RaycastHit2D hit = Physics2D.Raycast(ray.origin, ray.direction, enemyLayers);
-        if (hit.collider != null && hit.transform.gameObject.CompareTag(ENEMY_TAG))
-        {
-             _targetWasClicked = true;
-            UpdateTarget(hit.transform.gameObject);
-        }
-        else
-        {
-            // Clicked somewhere else on screen, deselect the target
-            UpdateTarget(null);
-            _targetWasClicked = false;
-        }   
-    }
-
-    void OnTriggerEnter2D(Collider2D other)
-    {
-        Debug.Log("Entered trigger");
-        if (_target == null && other.CompareTag(ENEMY_TAG))
-        {
-            Debug.Log("Updating target to " + other.name);
-            UpdateTarget(other.gameObject);
-            _targetWasClicked = false;
-        }
-    }
-
-    void OnTriggerExit2D(Collider2D other)
-    {
-        // If player clicked to target we should always respect it
-        // If target was selected by auto-fire then deselect when we go out of range
-        if (GameObject.ReferenceEquals(other.gameObject, _target) && !_targetWasClicked)
-        {
-            UpdateTarget(null);
-        }
-    }
-
-    void UpdateTarget(GameObject target)
-    {
-        _target = target;
         for (int i = 0; i < _cannons.Count; i++)
         {
             CannonContainer container = _cannons[i].GetComponent<CannonContainer>();
-            container.cannon.GetComponent<CannonStateMachine>().SetTarget(_target);
+            container.cannon.GetComponent<CannonStateMachine>().SetTarget(target);
         }
     }
 }

--- a/Sparrow/Assets/Scripts/Player/ShipTargeting.cs
+++ b/Sparrow/Assets/Scripts/Player/ShipTargeting.cs
@@ -1,0 +1,76 @@
+using UnityEngine;
+
+public class ShipTargeting : MonoBehaviour
+{
+    public ShipConfiguration shipConfig;
+    public GameObject target;
+    private bool _targetWasClicked = false;
+    private string ENEMY_TAG = "Enemy";
+
+    void Start()
+    {
+        target = null;
+    }
+
+    void Update()
+    {
+        if (Input.GetMouseButtonDown(0) && !PauseMenu.GameIsPaused)
+        {
+            SetTargetOnMouseClick();
+        }
+    }
+
+    void SetTargetOnMouseClick()
+    {
+        LayerMask enemyLayers = LayerMask.GetMask("Enemy");
+        Ray ray = Camera.main.ScreenPointToRay(Input.mousePosition);
+        RaycastHit2D hit = Physics2D.Raycast(ray.origin, ray.direction, Mathf.Infinity, enemyLayers);
+        if (hit.collider != null && hit.transform.gameObject.CompareTag(ENEMY_TAG))
+        {
+            target = hit.transform.gameObject;
+            shipConfig.UpdateTarget(target);
+            _targetWasClicked = true;
+        }
+        else
+        {
+            // Clicked somewhere else on screen, deselect the target
+            target = null;
+            shipConfig.UpdateTarget(target);
+            _targetWasClicked = false;
+        }   
+    }
+
+    // Enemy ship enters our shooting range
+    void OnTriggerEnter2D(Collider2D other)
+    {
+        if (target == null && other.CompareTag(ENEMY_TAG))
+        {   
+            target = other.gameObject;
+            shipConfig.UpdateTarget(target);
+            _targetWasClicked = false;
+        }
+    }
+
+    // When player deselects a manual target but is still in range of a ship, turn auto attack back on
+    void OnTriggerStay2D(Collider2D other)
+    {
+        if (target == null && other.CompareTag(ENEMY_TAG))
+        {
+            target = other.gameObject;
+            shipConfig.UpdateTarget(target);
+            _targetWasClicked = false;
+        }
+    }
+
+    void OnTriggerExit2D(Collider2D other)
+    {
+        // If player clicked to target we should always respect it
+        // If target was selected by auto-fire then deselect when we go out of range
+        if (ReferenceEquals(other.gameObject, target) && !_targetWasClicked)
+        {
+            target = null;
+            shipConfig.UpdateTarget(target);
+            _targetWasClicked = false;
+        }
+    }
+}

--- a/Sparrow/Assets/Scripts/Player/ShipTargeting.cs.meta
+++ b/Sparrow/Assets/Scripts/Player/ShipTargeting.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: bac8a4e0da2892e46a55a12b78969ec8
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Sparrow/Assets/Units/Cannons/TestCannon1.asset
+++ b/Sparrow/Assets/Units/Cannons/TestCannon1.asset
@@ -14,7 +14,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   name: TestBarrelTurret
   description: This fires stuff
-  attackStrength: 1
+  attackStrength: 2
   attackDistance: 5
   cannonSpriteOffsetFromBase: {x: -0.25, y: 0.2}
   firePointOffset: {x: -0.45, y: 0}

--- a/Sparrow/ProjectSettings/Physics2DSettings.asset
+++ b/Sparrow/ProjectSettings/Physics2DSettings.asset
@@ -3,7 +3,7 @@
 --- !u!19 &1
 Physics2DSettings:
   m_ObjectHideFlags: 0
-  serializedVersion: 5
+  serializedVersion: 6
   m_Gravity: {x: 0, y: -9.81}
   m_DefaultMaterial: {fileID: 0}
   m_VelocityIterations: 8
@@ -44,13 +44,5 @@ Physics2DSettings:
   m_CallbacksOnDisable: 1
   m_ReuseCollisionCallbacks: 1
   m_AutoSyncTransforms: 0
-  m_AlwaysShowColliders: 0
-  m_ShowColliderSleep: 1
-  m_ShowColliderContacts: 0
-  m_ShowColliderAABB: 0
-  m_ContactArrowScale: 0.2
-  m_ColliderAwakeColor: {r: 0.5686275, g: 0.95686275, b: 0.54509807, a: 0.7529412}
-  m_ColliderAsleepColor: {r: 0.5686275, g: 0.95686275, b: 0.54509807, a: 0.36078432}
-  m_ColliderContactColor: {r: 1, g: 0, b: 1, a: 0.6862745}
-  m_ColliderAABBColor: {r: 1, g: 1, b: 0, a: 0.2509804}
-  m_LayerCollisionMatrix: ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
+  m_GizmoOptions: 10
+  m_LayerCollisionMatrix: 08fcffff08fcffff48fcffffffffffff08fcffff08fcffff0cffffff08fdffffc8fdffff48fcffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff

--- a/Sparrow/ProjectSettings/TagManager.asset
+++ b/Sparrow/ProjectSettings/TagManager.asset
@@ -5,6 +5,8 @@ TagManager:
   serializedVersion: 2
   tags:
   - Enemy
+  - PlayerAttack
+  - EnemyAttack
   layers:
   - Default
   - TransparentFX


### PR DESCRIPTION
1. Added logic for enemies to keep track of health and take damage from player cannons.
2. Updated collision layer matrix and fixed bug with click to target raycast.
3. Added logic for auto-selecting targets in range of ship when clicking off primary target.
4. Refactored targeting logic into separate component script.

Known Issues:
1. Enemy death when selected via mouseclick does not update properly. Will be addressing in future commit with an Event PubSub like system (to also be used for handling level complete, loot drops, and similar things).
2. New collision layer matrix doesn't account for tile layers. Need to update ships and projectiles to respect tiles these as appropriate.