### PR TITLE
Fixing Tile Layer Collisions

### DIFF
--- a/Sparrow/Assets/MapGenerator/GrassTexture.prefab
+++ b/Sparrow/Assets/MapGenerator/GrassTexture.prefab
@@ -11,7 +11,7 @@ GameObject:
   - component: {fileID: 1458530536081597452}
   - component: {fileID: 2756727209766274381}
   - component: {fileID: -2747517899747673913}
-  m_Layer: 0
+  m_Layer: 10
   m_Name: GrassTexture
   m_TagString: Untagged
   m_Icon: {fileID: 0}

--- a/Sparrow/Assets/MapGenerator/SandTexture.prefab
+++ b/Sparrow/Assets/MapGenerator/SandTexture.prefab
@@ -11,7 +11,7 @@ GameObject:
   - component: {fileID: 8738988905993918705}
   - component: {fileID: 2934891449973209359}
   - component: {fileID: -4399088753897792223}
-  m_Layer: 0
+  m_Layer: 11
   m_Name: SandTexture
   m_TagString: Untagged
   m_Icon: {fileID: 0}

--- a/Sparrow/Assets/MapGenerator/WaterTexture.prefab
+++ b/Sparrow/Assets/MapGenerator/WaterTexture.prefab
@@ -10,7 +10,7 @@ GameObject:
   m_Component:
   - component: {fileID: 90603510914185317}
   - component: {fileID: 6289684261163721386}
-  m_Layer: 0
+  m_Layer: 12
   m_Name: WaterTexture
   m_TagString: Untagged
   m_Icon: {fileID: 0}

--- a/Sparrow/Assets/MapGenerator/prefabDeepWater.prefab
+++ b/Sparrow/Assets/MapGenerator/prefabDeepWater.prefab
@@ -10,7 +10,7 @@ GameObject:
   m_Component:
   - component: {fileID: 8048577682434080658}
   - component: {fileID: 8673676931803435969}
-  m_Layer: 0
+  m_Layer: 12
   m_Name: prefabDeepWater
   m_TagString: Untagged
   m_Icon: {fileID: 0}

--- a/Sparrow/Assets/Scenes/Battlefield.unity
+++ b/Sparrow/Assets/Scenes/Battlefield.unity
@@ -273,6 +273,7 @@ MonoBehaviour:
   prefabGrass: {fileID: 2594190323953209280, guid: 7f5f5de2ecec21c489b5d7f05fd28042, type: 3}
   player: {fileID: 6847842634037359419, guid: 9e7965dd074dd0a4abcb3864277b5d27, type: 3}
   enemyPrefab: {fileID: 1739139097824912367, guid: e6705a9387e6dc540b52c0d10860a8db, type: 3}
+  enemySpawned: {fileID: 11400000, guid: 116bf5fb3f66a75418355019acb7228a, type: 2}
   numberOfEnemies: 5
   enemySpawnRadius: 5
   minDistanceFromPlayer: 10
@@ -310,6 +311,109 @@ Transform:
   m_Children: []
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &215481226
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 215481229}
+  - component: {fileID: 215481228}
+  - component: {fileID: 215481230}
+  - component: {fileID: 215481227}
+  m_Layer: 0
+  m_Name: LevelManager
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &215481227
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 215481226}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 86ac7bf90a0b62a4e94d21eec0397cfc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  totalEnemies: 0
+--- !u!114 &215481228
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 215481226}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: d71e0b6cc8f7e5f4f85b219916a62af4, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  gameEvent: {fileID: 11400000, guid: 116bf5fb3f66a75418355019acb7228a, type: 2}
+  onEventTriggered:
+    m_PersistentCalls:
+      m_Calls:
+      - m_Target: {fileID: 215481227}
+        m_TargetAssemblyTypeName: LevelManager, Assembly-CSharp
+        m_MethodName: OnEnemySpawn
+        m_Mode: 0
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
+--- !u!4 &215481229
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 215481226}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 28.326658, y: 65.13905, z: 0.028320491}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &215481230
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 215481226}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: d71e0b6cc8f7e5f4f85b219916a62af4, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  gameEvent: {fileID: 11400000, guid: 414dfc9853bd0654daa1e3928b01376e, type: 2}
+  onEventTriggered:
+    m_PersistentCalls:
+      m_Calls:
+      - m_Target: {fileID: 215481227}
+        m_TargetAssemblyTypeName: LevelManager, Assembly-CSharp
+        m_MethodName: OnEnemyDeath
+        m_Mode: 0
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
 --- !u!1 &546189299
 GameObject:
   m_ObjectHideFlags: 0
@@ -1340,3 +1444,4 @@ SceneRoots:
   - {fileID: 75532890}
   - {fileID: 546189300}
   - {fileID: 2085329833}
+  - {fileID: 215481229}

--- a/Sparrow/Assets/Scripts/Cannons/CannonballLogic.cs
+++ b/Sparrow/Assets/Scripts/Cannons/CannonballLogic.cs
@@ -8,6 +8,10 @@ public class CannonballLogic : MonoBehaviour
     public Vector3 projectileSpawnPoint;
     public float projectileSpeed;
 
+    // From inspector
+    private int _enemyLayer = 8;
+    private int _grassLayer = 10;
+
     void Start()
     {
         projectileSpawnPoint = transform.position;
@@ -24,8 +28,11 @@ public class CannonballLogic : MonoBehaviour
     }
 
     void OnCollisionEnter2D(Collision2D other){
-        // Check if we hit something (land, enemy) that would cause us to explode
-        if (other.gameObject.CompareTag("Enemy"))
+        // Check if we hit something (land, enemy) that would cause us to "explode"
+        // Can combine into a LayerMask check but keeping separate in case we want to
+        // do something different based on the collision source
+        if (other.gameObject.layer == _enemyLayer ||
+            other.gameObject.layer == _grassLayer)
         {
             Destroy(gameObject);
         }

--- a/Sparrow/Assets/Settings/Lit2DSceneTemplate.scenetemplate
+++ b/Sparrow/Assets/Settings/Lit2DSceneTemplate.scenetemplate
@@ -66,8 +66,8 @@ MonoBehaviour:
     the 2D Renderer in Universal RP.
   preview: {fileID: -3604256930052969394}
   dependencies:
-  - dependency: {fileID: 2800000, guid: 442c1aed9d35e534696819bbd19338d9, type: 3}
-    instantiationMode: 0
+  - dependency: {fileID: 11400000, guid: 116bf5fb3f66a75418355019acb7228a, type: 2}
+    instantiationMode: 1
   - dependency: {fileID: 2800000, guid: b1c9b7c935f460240830a284bce96c3b, type: 3}
     instantiationMode: 0
   - dependency: {fileID: 9100000, guid: 21a2e19c324b1764182c524bb2e8b335, type: 2}
@@ -80,8 +80,6 @@ MonoBehaviour:
     instantiationMode: 0
   - dependency: {fileID: 248383343662709132, guid: 6b9d6f80cad33044893fbbf9221d52b1, type: 3}
     instantiationMode: 0
-  - dependency: {fileID: 7400000, guid: 627ff794b434b824d9ed188cbe58163e, type: 2}
-    instantiationMode: 0
   - dependency: {fileID: 8979340069536578346, guid: 09b108a04595b6540b97fc1ed5afdd6b, type: 3}
     instantiationMode: 0
   - dependency: {fileID: 7400000, guid: ed8b56d01da000b468b4898d4161cd34, type: 2}
@@ -92,14 +90,10 @@ MonoBehaviour:
     instantiationMode: 0
   - dependency: {fileID: 2800000, guid: 81ac09d6afe02284986eda815454b342, type: 3}
     instantiationMode: 0
-  - dependency: {fileID: 7400000, guid: 2df371ea71100e24d917af2462f3ad0a, type: 2}
-    instantiationMode: 0
-  - dependency: {fileID: 9100000, guid: af4c21d83b0bf724e8d33922b1d618ef, type: 2}
-    instantiationMode: 0
   - dependency: {fileID: 474650801237723220, guid: 06124022d7883c54998b6bcdbcf12a5a, type: 3}
     instantiationMode: 0
-  - dependency: {fileID: 5427650957570344865, guid: b2f844b181137dd4db4e25c00bed37c1, type: 3}
-    instantiationMode: 0
+  - dependency: {fileID: 11400000, guid: 414dfc9853bd0654daa1e3928b01376e, type: 2}
+    instantiationMode: 1
   - dependency: {fileID: 2800000, guid: af4e9c2d4fa12574a85fa188f63546fc, type: 3}
     instantiationMode: 0
   - dependency: {fileID: 2800000, guid: 10d9ce21a50180342b26948a013cac34, type: 3}
@@ -108,21 +102,13 @@ MonoBehaviour:
     instantiationMode: 0
   - dependency: {fileID: 2594190323953209280, guid: 7f5f5de2ecec21c489b5d7f05fd28042, type: 3}
     instantiationMode: 0
-  - dependency: {fileID: 2800000, guid: 3c3eeaf3753f14b459865cd6b0c81c4b, type: 3}
-    instantiationMode: 0
   - dependency: {fileID: 2800000, guid: 7d6931cb078d423419f636b5c80bbf4b, type: 3}
-    instantiationMode: 0
-  - dependency: {fileID: 7400000, guid: 746fd82dbc5bedc4ab4093bb7bc1b6eb, type: 2}
     instantiationMode: 0
   - dependency: {fileID: 5896505433429229737, guid: f2f0ec9b45559d54fb267a5477aefb2a, type: 3}
     instantiationMode: 0
   - dependency: {fileID: 2800000, guid: b9d6f9731e290cc40ac247831a4e29a7, type: 3}
     instantiationMode: 0
-  - dependency: {fileID: 11400000, guid: b10e627261f058b4ebf0e71ca3bfae5a, type: 2}
-    instantiationMode: 1
   - dependency: {fileID: 6847842634037359419, guid: 9e7965dd074dd0a4abcb3864277b5d27, type: 3}
-    instantiationMode: 0
-  - dependency: {fileID: 9100000, guid: 281f83d0860a20c44b342a3c12eefd31, type: 2}
     instantiationMode: 0
   - dependency: {fileID: 2800000, guid: 9ad5571e14ac03142bb2ebba94c1ac1a, type: 3}
     instantiationMode: 0


### PR DESCRIPTION
1. Adding new layers to tiles to distinguish types.
2. Updated collision matrix in project to reflect behavior "ships can't move onto land, ship can shoot across sand, but cannot shoot across grass".
3. Updated Cannoball logic to destroy itself on collision with grass as expected.
4. Updated Battlefield scene to include LevelManager from previous commit (I did not hit save on scene view before pushing lol)