### PR TITLE
Level Definition System

### DIFF
--- a/Sparrow/Assets/Scenes/Battlefield.unity
+++ b/Sparrow/Assets/Scenes/Battlefield.unity
@@ -249,6 +249,7 @@ GameObject:
   m_Component:
   - component: {fileID: 75532890}
   - component: {fileID: 75532889}
+  - component: {fileID: 75532891}
   m_Layer: 0
   m_Name: MapGenerator
   m_TagString: Untagged
@@ -312,6 +313,34 @@ Transform:
   m_Children: []
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &75532891
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 75532888}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: d71e0b6cc8f7e5f4f85b219916a62af4, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  gameEvent: {fileID: 11400000, guid: 2beee4ca3cbcfad4b83f26ea70d6c0e0, type: 2}
+  onEventTriggered:
+    m_PersistentCalls:
+      m_Calls:
+      - m_Target: {fileID: 75532889}
+        m_TargetAssemblyTypeName: MapGeneratorWithSpawn, Assembly-CSharp
+        m_MethodName: OnLevelLoad
+        m_Mode: 0
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
 --- !u!1 &184130637
 GameObject:
   m_ObjectHideFlags: 0
@@ -419,6 +448,8 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   totalEnemies: 0
+  levelDefinition: {fileID: 0}
+  LevelLoaded: {fileID: 11400000, guid: 2beee4ca3cbcfad4b83f26ea70d6c0e0, type: 2}
 --- !u!114 &215481228
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/Sparrow/Assets/Scenes/Menus/TitleMenu.unity
+++ b/Sparrow/Assets/Scenes/Menus/TitleMenu.unity
@@ -470,6 +470,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   newGameScene: Scenes/Battlefield
+  gameStartLevel: {fileID: 11400000, guid: 9c9bc89b524547d44a84dcafea3e6d12, type: 2}
 --- !u!4 &722231711
 Transform:
   m_ObjectHideFlags: 0

--- a/Sparrow/Assets/Scripts/Events/LevelLoaded.asset
+++ b/Sparrow/Assets/Scripts/Events/LevelLoaded.asset
@@ -1,0 +1,14 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: e07af557ca8d0ce418ddd5ef736576f4, type: 3}
+  m_Name: LevelLoaded
+  m_EditorClassIdentifier: 

--- a/Sparrow/Assets/Scripts/Events/LevelLoaded.asset.meta
+++ b/Sparrow/Assets/Scripts/Events/LevelLoaded.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 2beee4ca3cbcfad4b83f26ea70d6c0e0
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Sparrow/Assets/Scripts/GameState/GlobalVariables.cs
+++ b/Sparrow/Assets/Scripts/GameState/GlobalVariables.cs
@@ -1,0 +1,36 @@
+using System.Collections.Generic;
+
+public static class GlobalVariables
+{
+    private static readonly object _lockObject = new object();
+    private static Dictionary<string, object> _variablesDictionary = new Dictionary<string, object>();
+
+    public static Dictionary<string, object> VariablesDictionary => _variablesDictionary;
+
+    public static Dictionary<string, object> GetAll()
+    {
+        return _variablesDictionary;
+    }
+
+    public static T Get<T>(string key)
+    {
+        if (_variablesDictionary == null || !_variablesDictionary.ContainsKey(key))
+        {
+            return default;
+        }
+
+        return (T)_variablesDictionary[key];
+    }
+
+    public static void Set(string key, object value)
+    {
+        lock(_lockObject)
+        {
+            if (_variablesDictionary == null)
+            {
+                _variablesDictionary = new Dictionary<string, object>();
+            }
+        }
+        _variablesDictionary[key] = value;
+    }
+}

--- a/Sparrow/Assets/Scripts/GameState/GlobalVariables.cs.meta
+++ b/Sparrow/Assets/Scripts/GameState/GlobalVariables.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: a90678e6f2aeee14d8dc9a67cd537cb9
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Sparrow/Assets/Scripts/GameState/LevelManager.cs
+++ b/Sparrow/Assets/Scripts/GameState/LevelManager.cs
@@ -1,22 +1,39 @@
-using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
+using UnityEngine.SceneManagement;
 
 public class LevelManager : MonoBehaviour
 {
     public int totalEnemies = 0;
+    public LevelDefinition levelDefinition;
+
+    public static string NEXT_LEVEL = "Next Level";
+    public GameEvent LevelLoaded;
     
     private List<GameObject> _enemies = new List<GameObject>();
     private bool _levelCleared = false;
 
+    void Start()
+    {
+        LevelDefinition requestedLevel = GlobalVariables.Get<LevelDefinition>(NEXT_LEVEL);
+        if (requestedLevel != null)
+        {
+            levelDefinition = requestedLevel;
+        }
+        Debug.Log("Loaded level " + levelDefinition.name);
+        LevelLoaded.TriggerEvent(gameObject);
+    }
+
+    public void LoadNextLevel()
+    {
+        GlobalVariables.Set(NEXT_LEVEL, levelDefinition.nextLevel);
+        SceneManager.LoadScene("Scenes/Battlefield");
+    }
+
+
     void Update()
     {
-        if (!_levelCleared && _enemies.Count <= 0)
-        {
-            Metrics.RegisterLevelCleared(totalEnemies);
-            _levelCleared = true;
-            Debug.Log("Level Cleared");
-        }
+
     }
 
     public void OnEnemySpawn(GameObject eventSource)
@@ -29,5 +46,13 @@ public class LevelManager : MonoBehaviour
     {
         _enemies.RemoveAll(enemy => ReferenceEquals(enemy, eventSource));
         Metrics.RegisterEnemyKilled(eventSource);
+        if (!_levelCleared && _enemies.Count <= 0)
+        {
+            Metrics.RegisterLevelCleared(totalEnemies);
+            _levelCleared = true;
+            Debug.Log("Level Cleared");
+            // TODO: Add timer or some mechanism to gate this so player has time to collect loot
+            LoadNextLevel();
+        }
     }
 }

--- a/Sparrow/Assets/Scripts/Levels.meta
+++ b/Sparrow/Assets/Scripts/Levels.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 9f686f684f3afaa44b9fa1fa6423c2e3
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Sparrow/Assets/Scripts/Levels/Level1.asset
+++ b/Sparrow/Assets/Scripts/Levels/Level1.asset
@@ -1,0 +1,19 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 9cfcda6365f4eae4396f1f23e45bb59a, type: 3}
+  m_Name: Level1
+  m_EditorClassIdentifier: 
+  name: Level 1 (Game Start)
+  enemiesToSpawn:
+  - Enemy: {fileID: 1739139097824912367, guid: e6705a9387e6dc540b52c0d10860a8db, type: 3}
+    Count: 1
+  nextLevel: {fileID: 11400000, guid: 7684873cb041e3448ae15d02e29d6b67, type: 2}

--- a/Sparrow/Assets/Scripts/Levels/Level1.asset.meta
+++ b/Sparrow/Assets/Scripts/Levels/Level1.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 9c9bc89b524547d44a84dcafea3e6d12
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Sparrow/Assets/Scripts/Levels/Level2.asset
+++ b/Sparrow/Assets/Scripts/Levels/Level2.asset
@@ -1,0 +1,19 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 9cfcda6365f4eae4396f1f23e45bb59a, type: 3}
+  m_Name: Level2
+  m_EditorClassIdentifier: 
+  name: 'Level 2: The Squeakquel'
+  enemiesToSpawn:
+  - Enemy: {fileID: 1739139097824912367, guid: e6705a9387e6dc540b52c0d10860a8db, type: 3}
+    Count: 5
+  nextLevel: {fileID: 0}

--- a/Sparrow/Assets/Scripts/Levels/Level2.asset.meta
+++ b/Sparrow/Assets/Scripts/Levels/Level2.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 7684873cb041e3448ae15d02e29d6b67
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Sparrow/Assets/Scripts/Levels/LevelDefintion.cs
+++ b/Sparrow/Assets/Scripts/Levels/LevelDefintion.cs
@@ -1,0 +1,18 @@
+using System.Collections.Generic;
+using UnityEngine;
+
+[CreateAssetMenu(menuName ="Level Configuration")]
+public class LevelDefinition : ScriptableObject
+{
+    [System.Serializable]
+    public class EnemyConfiguration
+    {
+        public GameObject Enemy;
+        public int Count;
+    }
+
+    // mark as new  to tell Unity to always use this specific value when referencing name
+    public new string name;
+    public List<EnemyConfiguration> enemiesToSpawn = new List<EnemyConfiguration>();
+    public LevelDefinition nextLevel;
+}

--- a/Sparrow/Assets/Scripts/Levels/LevelDefintion.cs.meta
+++ b/Sparrow/Assets/Scripts/Levels/LevelDefintion.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 9cfcda6365f4eae4396f1f23e45bb59a
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Sparrow/Assets/Scripts/MapGenerator/MapGeneratorWithSpawn.cs
+++ b/Sparrow/Assets/Scripts/MapGenerator/MapGeneratorWithSpawn.cs
@@ -53,9 +53,10 @@ public class MapGeneratorWithSpawn : MonoBehaviour
     //Ref to CameraController
     public CameraController cameraController;
 
-    //Activations on Start
-    void Start()
+    //Activations on LevelLoaded
+    public void OnLevelLoad(GameObject levelManager)
     {
+        LevelDefinition levelDefinition = levelManager.GetComponent<LevelManager>().levelDefinition;
         CreateTileset();
         CreateTileGroups();
         GenerateNoiseMap();
@@ -66,7 +67,7 @@ public class MapGeneratorWithSpawn : MonoBehaviour
         Vector3 playerSpawnPosition = AddCharacterSpawnerToRandomTileOfType(prefabDeepWater);
 
         FindEnemySpawnPoints();
-        SpawnEnemies();
+        SpawnEnemies(levelDefinition.enemiesToSpawn);
 
         Vector3 mapCenter = new Vector3(mapWidth / 2, mapHeight / 2, 0);
 
@@ -361,7 +362,7 @@ public class MapGeneratorWithSpawn : MonoBehaviour
         }
     }
 
-    void SpawnEnemies()
+    void SpawnEnemies(List<LevelDefinition.EnemyConfiguration> enemiesToSpawn)
     {
         if (enemySpawnPoints.Count == 0)
         {
@@ -375,14 +376,18 @@ public class MapGeneratorWithSpawn : MonoBehaviour
             return;
         }
 
-        for (int i = 0; i < numberOfEnemies; i++)
+        foreach (LevelDefinition.EnemyConfiguration enemyType in enemiesToSpawn)
         {
-            Vector2Int spawnPoint = enemySpawnPoints[Random.Range(0, enemySpawnPoints.Count)];
-            Vector3 spawnPosition = new Vector3(spawnPoint.x, spawnPoint.y, 0);
+            int numberOfEnemies = enemyType.Count;
+            GameObject enemyPrefab = enemyType.Enemy;
+            for (int i = 0; i < numberOfEnemies; i++)
+            {
+                Vector2Int spawnPoint = enemySpawnPoints[Random.Range(0, enemySpawnPoints.Count)];
+                Vector3 spawnPosition = new Vector3(spawnPoint.x, spawnPoint.y, 0);
 
-            // Ensure enemies are spawned at least 'minDistanceFromCharacterSpawner' away from the character
-            float distanceFromPlayer = Vector3.Distance(spawnPosition, player.transform.position);
-            if (distanceFromPlayer < minDistanceFromPlayer)
+                // Ensure enemies are spawned at least 'minDistanceFromCharacterSpawner' away from the character
+                float distanceFromPlayer = Vector3.Distance(spawnPosition, player.transform.position);
+                if (distanceFromPlayer < minDistanceFromPlayer)
                 {
                     i--;
                     continue;
@@ -390,6 +395,7 @@ public class MapGeneratorWithSpawn : MonoBehaviour
 
                 GameObject enemy = Instantiate(enemyPrefab, spawnPosition, Quaternion.identity);
                 enemySpawned.TriggerEvent(enemy);
-            }            
-        }
+            }
+        }            
     }
+}

--- a/Sparrow/Assets/Scripts/Menus/TitleMenuLogic.cs
+++ b/Sparrow/Assets/Scripts/Menus/TitleMenuLogic.cs
@@ -1,11 +1,10 @@
-using System.Collections;
-using System.Collections.Generic;
 using UnityEngine;
 using UnityEngine.SceneManagement;
 
 public class TitleMenuLogic : MonoBehaviour
 {
     public string newGameScene;
+    public LevelDefinition gameStartLevel;
 
     public void Start()
     {
@@ -16,6 +15,7 @@ public class TitleMenuLogic : MonoBehaviour
 
     public void loadNewGame()
     {
+        GlobalVariables.Set(LevelManager.NEXT_LEVEL, gameStartLevel);
         SceneManager.LoadScene(newGameScene);
     }
 

--- a/Sparrow/Assets/Settings/Lit2DSceneTemplate.scenetemplate
+++ b/Sparrow/Assets/Settings/Lit2DSceneTemplate.scenetemplate
@@ -82,8 +82,6 @@ MonoBehaviour:
     instantiationMode: 0
   - dependency: {fileID: 5743417108097213276, guid: 8294936f375755e46bb734b3c3af1913, type: 3}
     instantiationMode: 0
-  - dependency: {fileID: 11400000, guid: 7951c64df9968d24792219d7a48e486d, type: 2}
-    instantiationMode: 1
   - dependency: {fileID: 11400000, guid: d8ed48c2720aaa64d8e7a6961abaafca, type: 2}
     instantiationMode: 1
   - dependency: {fileID: 11400000, guid: b1edf3c5d1e23fc448ebc5d74f661a49, type: 2}
@@ -120,10 +118,14 @@ MonoBehaviour:
     instantiationMode: 0
   - dependency: {fileID: 2594190323953209280, guid: 7f5f5de2ecec21c489b5d7f05fd28042, type: 3}
     instantiationMode: 0
-  - dependency: {fileID: 2800000, guid: 7d6931cb078d423419f636b5c80bbf4b, type: 3}
-    instantiationMode: 0
+  - dependency: {fileID: 11400000, guid: 7684873cb041e3448ae15d02e29d6b67, type: 2}
+    instantiationMode: 1
+  - dependency: {fileID: 11400000, guid: 9c9bc89b524547d44a84dcafea3e6d12, type: 2}
+    instantiationMode: 1
   - dependency: {fileID: 11400000, guid: 432663453bd6f49438f99859c08730ce, type: 2}
     instantiationMode: 1
+  - dependency: {fileID: 2800000, guid: 7d6931cb078d423419f636b5c80bbf4b, type: 3}
+    instantiationMode: 0
   - dependency: {fileID: 5896505433429229737, guid: f2f0ec9b45559d54fb267a5477aefb2a, type: 3}
     instantiationMode: 0
   - dependency: {fileID: 2800000, guid: b9d6f9731e290cc40ac247831a4e29a7, type: 3}
@@ -135,6 +137,8 @@ MonoBehaviour:
   - dependency: {fileID: 2800000, guid: 9ad5571e14ac03142bb2ebba94c1ac1a, type: 3}
     instantiationMode: 0
   - dependency: {fileID: 11400000, guid: 525f618103afe3d499e29e13d20c11bd, type: 2}
+    instantiationMode: 1
+  - dependency: {fileID: 11400000, guid: 2beee4ca3cbcfad4b83f26ea70d6c0e0, type: 2}
     instantiationMode: 1
   templatePipeline: {fileID: 0}
   badge: {fileID: 0}


### PR DESCRIPTION
1. Added basic system for defining levels as groups of enemies to spawn, and a pointer to the next level definition.
2. Extended LevelManager to parse this struct and load current level enemy configurations and handle reloading battlefield with the "NextLevel" configuration on level completion.

ToDos:
1. Improve UX of level completion to allow players to collect loot before next level loads
2. Gracefully handle case where there is no next level to load after current one completes.
3. Persist player attributes across level loads (health, gold, cannon configs)