### PR TITLE
PursueUpdate

### DIFF
--- a/Sparrow/Assets/MapGenerator/GrassTexture.prefab
+++ b/Sparrow/Assets/MapGenerator/GrassTexture.prefab
@@ -10,10 +10,9 @@ GameObject:
   m_Component:
   - component: {fileID: 1458530536081597452}
   - component: {fileID: 2756727209766274381}
-  - component: {fileID: -2747517899747673913}
   m_Layer: 10
   m_Name: GrassTexture
-  m_TagString: Untagged
+  m_TagString: Obstacle
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
@@ -85,48 +84,3 @@ SpriteRenderer:
   m_WasSpriteAssigned: 1
   m_MaskInteraction: 0
   m_SpriteSortPoint: 0
---- !u!61 &-2747517899747673913
-BoxCollider2D:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2594190323953209280}
-  m_Enabled: 1
-  m_Density: 1
-  m_Material: {fileID: 0}
-  m_IncludeLayers:
-    serializedVersion: 2
-    m_Bits: 0
-  m_ExcludeLayers:
-    serializedVersion: 2
-    m_Bits: 0
-  m_LayerOverridePriority: 0
-  m_ForceSendLayers:
-    serializedVersion: 2
-    m_Bits: 4294967295
-  m_ForceReceiveLayers:
-    serializedVersion: 2
-    m_Bits: 4294967295
-  m_ContactCaptureLayers:
-    serializedVersion: 2
-    m_Bits: 4294967295
-  m_CallbackLayers:
-    serializedVersion: 2
-    m_Bits: 4294967295
-  m_IsTrigger: 0
-  m_UsedByEffector: 0
-  m_UsedByComposite: 0
-  m_Offset: {x: 0, y: 0}
-  m_SpriteTilingProperty:
-    border: {x: 0, y: 0, z: 0, w: 0}
-    pivot: {x: 0.5, y: 0.5}
-    oldSize: {x: 1, y: 1}
-    newSize: {x: 1, y: 1}
-    adaptiveTilingThreshold: 0.5
-    drawMode: 0
-    adaptiveTiling: 0
-  m_AutoTiling: 0
-  serializedVersion: 2
-  m_Size: {x: 1, y: 1}
-  m_EdgeRadius: 0

--- a/Sparrow/Assets/MapGenerator/SandTexture.prefab
+++ b/Sparrow/Assets/MapGenerator/SandTexture.prefab
@@ -10,10 +10,10 @@ GameObject:
   m_Component:
   - component: {fileID: 8738988905993918705}
   - component: {fileID: 2934891449973209359}
-  - component: {fileID: -4399088753897792223}
+  - component: {fileID: 3653785144342774195}
   m_Layer: 11
   m_Name: SandTexture
-  m_TagString: Untagged
+  m_TagString: Obstacle
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
@@ -85,7 +85,7 @@ SpriteRenderer:
   m_WasSpriteAssigned: 1
   m_MaskInteraction: 0
   m_SpriteSortPoint: 0
---- !u!61 &-4399088753897792223
+--- !u!61 &3653785144342774195
 BoxCollider2D:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -116,7 +116,7 @@ BoxCollider2D:
     m_Bits: 4294967295
   m_IsTrigger: 0
   m_UsedByEffector: 0
-  m_UsedByComposite: 0
+  m_UsedByComposite: 1
   m_Offset: {x: 0, y: 0}
   m_SpriteTilingProperty:
     border: {x: 0, y: 0, z: 0, w: 0}

--- a/Sparrow/Assets/Prefabs/EnemyShipTEST1-Sheet(Mast).prefab
+++ b/Sparrow/Assets/Prefabs/EnemyShipTEST1-Sheet(Mast).prefab
@@ -11,7 +11,6 @@ GameObject:
   - component: {fileID: 2803948586991084623}
   - component: {fileID: 5003059879823418541}
   - component: {fileID: 4332703334164343706}
-  - component: {fileID: -6183314917113772691}
   - component: {fileID: 605418080969120408}
   - component: {fileID: 974075676751969829}
   - component: {fileID: 7149692812225392152}
@@ -31,7 +30,7 @@ Transform:
   m_GameObject: {fileID: 1739139097824912367}
   serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalPosition: {x: 61.74653, y: 30.702202, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
@@ -97,7 +96,7 @@ Rigidbody2D:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1739139097824912367}
-  m_BodyType: 1
+  m_BodyType: 0
   m_Simulated: 1
   m_UseFullKinematicContacts: 0
   m_UseAutoMass: 0
@@ -116,19 +115,6 @@ Rigidbody2D:
   m_SleepingMode: 1
   m_CollisionDetection: 0
   m_Constraints: 4
---- !u!114 &-6183314917113772691
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1739139097824912367}
-  m_Enabled: 0
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: b80be2e4c4ee62841af503b8f9d8fc0c, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  speed: 1.5
 --- !u!70 &605418080969120408
 CapsuleCollider2D:
   m_ObjectHideFlags: 0
@@ -176,6 +162,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 18a9049f58596d741951f3caafddfaf7, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  healthChanged: {fileID: 0}
   onDeath: {fileID: 11400000, guid: 414dfc9853bd0654daa1e3928b01376e, type: 2}
   damageSourceTags: 00000000
   HitPoints: 5
@@ -191,4 +178,4 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 545aeb05ff8efda4fa37ca43d2560716, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  _initialState: {fileID: 11400000, guid: a70cd4b7380fd004e9f9e8a5e441ddab, type: 2}
+  _initialState: {fileID: 11400000, guid: bc5b51c68f3e3314bbbc20628a42d13e, type: 2}

--- a/Sparrow/Assets/Scenes/Battlefield.unity
+++ b/Sparrow/Assets/Scenes/Battlefield.unity
@@ -280,10 +280,10 @@ MonoBehaviour:
   minDistanceFromPlayer: 10
   mapWidth: 120
   mapHeight: 68
-  noiseScale: 30
-  octaves: 3
-  persistence: 0.1
-  lacunarity: 10
+  noiseScale: 25
+  octaves: 6
+  persistence: 0.01
+  lacunarity: 4
   seed: 0
   heightCurve:
     serializedVersion: 2
@@ -296,7 +296,9 @@ MonoBehaviour:
   gameObjectAddCollider:
   - {fileID: 5896505433429229737, guid: f2f0ec9b45559d54fb267a5477aefb2a, type: 3}
   - {fileID: 2594190323953209280, guid: 7f5f5de2ecec21c489b5d7f05fd28042, type: 3}
-  cameraController: {fileID: 2085329832}
+  playerTransform: {fileID: 3558335276874133501, guid: 9e7965dd074dd0a4abcb3864277b5d27, type: 3}
+  mapCenterTransform: {fileID: 2085329833}
+  cameraController: {fileID: 2085329834}
 --- !u!4 &75532890
 Transform:
   m_ObjectHideFlags: 0
@@ -732,6 +734,94 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 842857136}
   m_CullTransparentMesh: 1
+--- !u!1 &993635737
+GameObject:
+  m_ObjectHideFlags: 3
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 993635738}
+  - component: {fileID: 993635740}
+  - component: {fileID: 993635739}
+  m_Layer: 0
+  m_Name: cm
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &993635738
+Transform:
+  m_ObjectHideFlags: 3
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 993635737}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1332160138}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &993635739
+MonoBehaviour:
+  m_ObjectHideFlags: 3
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 993635737}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 6ad980451443d70438faac0bc6c235a0, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_TrackedObjectOffset: {x: 0, y: 0, z: 0}
+  m_LookaheadTime: 0
+  m_LookaheadSmoothing: 0
+  m_LookaheadIgnoreY: 0
+  m_XDamping: 1
+  m_YDamping: 1
+  m_ZDamping: 1
+  m_TargetMovementOnly: 1
+  m_ScreenX: 0.5
+  m_ScreenY: 0.5
+  m_CameraDistance: 10
+  m_DeadZoneWidth: 0
+  m_DeadZoneHeight: 0
+  m_DeadZoneDepth: 0
+  m_UnlimitedSoftZone: 0
+  m_SoftZoneWidth: 0.8
+  m_SoftZoneHeight: 0.8
+  m_BiasX: 0
+  m_BiasY: 0
+  m_CenterOnActivate: 1
+  m_GroupFramingMode: 2
+  m_AdjustmentMode: 0
+  m_GroupFramingSize: 0.8
+  m_MaxDollyIn: 5000
+  m_MaxDollyOut: 5000
+  m_MinimumDistance: 1
+  m_MaximumDistance: 5000
+  m_MinimumFOV: 3
+  m_MaximumFOV: 60
+  m_MinimumOrthoSize: 1
+  m_MaximumOrthoSize: 5000
+--- !u!114 &993635740
+MonoBehaviour:
+  m_ObjectHideFlags: 3
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 993635737}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: ac0b09e7857660247b1477e93731de29, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1 &1014711322
 GameObject:
   m_ObjectHideFlags: 0
@@ -865,6 +955,78 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1014711322}
   m_CullTransparentMesh: 1
+--- !u!1 &1332160136
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1332160138}
+  - component: {fileID: 1332160137}
+  m_Layer: 0
+  m_Name: Virtual Camera
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &1332160137
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1332160136}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 45e653bab7fb20e499bda25e1b646fea, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_ExcludedPropertiesInInspector:
+  - m_Script
+  m_LockStageInInspector: 
+  m_StreamingVersion: 20170927
+  m_Priority: 10
+  m_StandbyUpdate: 2
+  m_LookAt: {fileID: 0}
+  m_Follow: {fileID: 0}
+  m_Lens:
+    FieldOfView: 130
+    OrthographicSize: 5
+    NearClipPlane: 0.3
+    FarClipPlane: 1000
+    Dutch: 0
+    ModeOverride: 0
+    LensShift: {x: 0, y: 0}
+    GateFit: 2
+    FocusDistance: 10
+    m_SensorSize: {x: 1, y: 1}
+  m_Transitions:
+    m_BlendHint: 0
+    m_InheritPosition: 0
+    m_OnCameraLive:
+      m_PersistentCalls:
+        m_Calls: []
+  m_LegacyBlendHint: 0
+  m_ComponentOwner: {fileID: 993635738}
+--- !u!4 &1332160138
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1332160136}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 457, y: 202, z: -31.040018}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 993635738}
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1398541027
 GameObject:
   m_ObjectHideFlags: 0
@@ -1276,6 +1438,7 @@ GameObject:
   - component: {fileID: 1553737048}
   - component: {fileID: 1553737047}
   - component: {fileID: 1553737046}
+  - component: {fileID: 1553737049}
   m_Layer: 0
   m_Name: Camera
   m_TagString: MainCamera
@@ -1324,7 +1487,7 @@ Camera:
     height: 1
   near clip plane: 0.3
   far clip plane: 1000
-  field of view: 60
+  field of view: 130
   orthographic: 0
   orthographic size: 5
   m_Depth: -1
@@ -1351,12 +1514,46 @@ Transform:
   m_GameObject: {fileID: 1553737045}
   serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: -10}
+  m_LocalPosition: {x: 457, y: 202, z: -31.040018}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &1553737049
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1553737045}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 72ece51f2901e7445ab60da3685d6b5f, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_ShowDebugText: 0
+  m_ShowCameraFrustum: 1
+  m_IgnoreTimeScale: 0
+  m_WorldUpOverride: {fileID: 0}
+  m_UpdateMethod: 2
+  m_BlendUpdateMethod: 1
+  m_DefaultBlend:
+    m_Style: 1
+    m_Time: 2
+    m_CustomCurve:
+      serializedVersion: 2
+      m_Curve: []
+      m_PreInfinity: 2
+      m_PostInfinity: 2
+      m_RotationOrder: 4
+  m_CustomBlends: {fileID: 0}
+  m_CameraCutEvent:
+    m_PersistentCalls:
+      m_Calls: []
+  m_CameraActivatedEvent:
+    m_PersistentCalls:
+      m_Calls: []
 --- !u!1 &1711794222
 GameObject:
   m_ObjectHideFlags: 0
@@ -1712,7 +1909,7 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 2085329833}
-  - component: {fileID: 2085329832}
+  - component: {fileID: 2085329834}
   m_Layer: 0
   m_Name: CameraController
   m_TagString: Untagged
@@ -1720,25 +1917,6 @@ GameObject:
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
---- !u!114 &2085329832
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2085329831}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 4b76460235d9056438b9d37dd404da00, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  cameraComponent: {fileID: 1553737047}
-  zoomOutDelay: 2
-  zoomOutDuration: 3
-  closeUpDistance: 15
-  zoomOutDistance: 10
-  minFOV: 75
-  maxFOV: 148
 --- !u!4 &2085329833
 Transform:
   m_ObjectHideFlags: 0
@@ -1754,6 +1932,20 @@ Transform:
   m_Children: []
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &2085329834
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2085329831}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 76b0b408d7ba93240850d8678abb785b, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  virtualCamera: {fileID: 1332160137}
+  cameraZoom: 10
 --- !u!1 &2107545646
 GameObject:
   m_ObjectHideFlags: 0
@@ -1979,3 +2171,4 @@ SceneRoots:
   - {fileID: 215481229}
   - {fileID: 1398541030}
   - {fileID: 1899862654}
+  - {fileID: 1332160138}

--- a/Sparrow/Assets/Scenes/Battlefield.unity
+++ b/Sparrow/Assets/Scenes/Battlefield.unity
@@ -122,6 +122,78 @@ NavMeshSettings:
     debug:
       m_Flags: 0
   m_NavMeshData: {fileID: 0}
+--- !u!1 &63859801
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 63859803}
+  - component: {fileID: 63859802}
+  m_Layer: 0
+  m_Name: Virtual Camera
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &63859802
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 63859801}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 45e653bab7fb20e499bda25e1b646fea, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_ExcludedPropertiesInInspector:
+  - m_Script
+  m_LockStageInInspector: 
+  m_StreamingVersion: 20170927
+  m_Priority: 10
+  m_StandbyUpdate: 2
+  m_LookAt: {fileID: 0}
+  m_Follow: {fileID: 0}
+  m_Lens:
+    FieldOfView: 60
+    OrthographicSize: 5
+    NearClipPlane: 0.3
+    FarClipPlane: 1000
+    Dutch: 0
+    ModeOverride: 0
+    LensShift: {x: 0, y: 0}
+    GateFit: 2
+    FocusDistance: 10
+    m_SensorSize: {x: 1, y: 1}
+  m_Transitions:
+    m_BlendHint: 0
+    m_InheritPosition: 0
+    m_OnCameraLive:
+      m_PersistentCalls:
+        m_Calls: []
+  m_LegacyBlendHint: 0
+  m_ComponentOwner: {fileID: 722009065}
+--- !u!4 &63859803
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 63859801}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: -10.494439, y: -19.265398, z: -102.34687}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 722009065}
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &64053592
 GameObject:
   m_ObjectHideFlags: 0
@@ -296,8 +368,8 @@ MonoBehaviour:
   gameObjectAddCollider:
   - {fileID: 5896505433429229737, guid: f2f0ec9b45559d54fb267a5477aefb2a, type: 3}
   - {fileID: 2594190323953209280, guid: 7f5f5de2ecec21c489b5d7f05fd28042, type: 3}
-  playerTransform: {fileID: 3558335276874133501, guid: 9e7965dd074dd0a4abcb3864277b5d27, type: 3}
-  mapCenterTransform: {fileID: 2085329833}
+  playerTransform: {fileID: 0}
+  mapCenterTransform: {fileID: 0}
   cameraController: {fileID: 2085329834}
 --- !u!4 &75532890
 Transform:
@@ -576,6 +648,94 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   characterPrefab: {fileID: 6847842634037359419, guid: 9e7965dd074dd0a4abcb3864277b5d27, type: 3}
+--- !u!1 &722009064
+GameObject:
+  m_ObjectHideFlags: 3
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 722009065}
+  - component: {fileID: 722009067}
+  - component: {fileID: 722009066}
+  m_Layer: 0
+  m_Name: cm
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &722009065
+Transform:
+  m_ObjectHideFlags: 3
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 722009064}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 63859803}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &722009066
+MonoBehaviour:
+  m_ObjectHideFlags: 3
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 722009064}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 6ad980451443d70438faac0bc6c235a0, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_TrackedObjectOffset: {x: 0, y: 0, z: 0}
+  m_LookaheadTime: 0
+  m_LookaheadSmoothing: 0
+  m_LookaheadIgnoreY: 0
+  m_XDamping: 1
+  m_YDamping: 1
+  m_ZDamping: 1
+  m_TargetMovementOnly: 1
+  m_ScreenX: 0.5
+  m_ScreenY: 0.5
+  m_CameraDistance: 25
+  m_DeadZoneWidth: 0
+  m_DeadZoneHeight: 0
+  m_DeadZoneDepth: 0
+  m_UnlimitedSoftZone: 0
+  m_SoftZoneWidth: 0.8
+  m_SoftZoneHeight: 0.8
+  m_BiasX: 0
+  m_BiasY: 0
+  m_CenterOnActivate: 1
+  m_GroupFramingMode: 2
+  m_AdjustmentMode: 0
+  m_GroupFramingSize: 0.8
+  m_MaxDollyIn: 5000
+  m_MaxDollyOut: 5000
+  m_MinimumDistance: 1
+  m_MaximumDistance: 5000
+  m_MinimumFOV: 3
+  m_MaximumFOV: 60
+  m_MinimumOrthoSize: 1
+  m_MaximumOrthoSize: 5000
+--- !u!114 &722009067
+MonoBehaviour:
+  m_ObjectHideFlags: 3
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 722009064}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: ac0b09e7857660247b1477e93731de29, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1 &825750298
 GameObject:
   m_ObjectHideFlags: 0
@@ -1514,7 +1674,7 @@ Transform:
   m_GameObject: {fileID: 1553737045}
   serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 457, y: 202, z: -31.040018}
+  m_LocalPosition: {x: -10.494439, y: -19.265398, z: -102.34687}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
@@ -1925,7 +2085,7 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 2085329831}
   serializedVersion: 2
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
@@ -1944,7 +2104,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 76b0b408d7ba93240850d8678abb785b, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  virtualCamera: {fileID: 1332160137}
+  virtualCamera: {fileID: 63859802}
   cameraZoom: 10
 --- !u!1 &2107545646
 GameObject:
@@ -2166,9 +2326,9 @@ SceneRoots:
   - {fileID: 64053596}
   - {fileID: 1991250827}
   - {fileID: 75532890}
-  - {fileID: 546189300}
   - {fileID: 2085329833}
+  - {fileID: 546189300}
   - {fileID: 215481229}
   - {fileID: 1398541030}
   - {fileID: 1899862654}
-  - {fileID: 1332160138}
+  - {fileID: 63859803}

--- a/Sparrow/Assets/Scripts/Camera/CinemachineCameraController.cs
+++ b/Sparrow/Assets/Scripts/Camera/CinemachineCameraController.cs
@@ -1,0 +1,31 @@
+using Cinemachine;
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class CinemachineCameraController : MonoBehaviour
+{
+    public CinemachineVirtualCamera virtualCamera;
+    public float cameraZoom = 10f; // Adjust as needed
+
+    // Method to set camera target
+    public void SetCameraTarget(Transform playerTransform, Vector3 mapCenter)
+    {
+        if (virtualCamera != null)
+        {
+            // Set the camera follow target to the player
+            virtualCamera.Follow = playerTransform;
+
+            // Adjust the camera zoom level
+            virtualCamera.m_Lens.OrthographicSize = cameraZoom;
+
+            // Optional: Center the camera on the map
+            Vector3 cameraPosition = new Vector3(mapCenter.x, mapCenter.y, virtualCamera.transform.position.z);
+            virtualCamera.transform.position = cameraPosition;
+        }
+        else
+        {
+            Debug.LogError("Cinemachine Virtual Camera reference is not set.");
+        }
+    }
+}

--- a/Sparrow/Assets/Scripts/Camera/CinemachineCameraController.cs.meta
+++ b/Sparrow/Assets/Scripts/Camera/CinemachineCameraController.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 76b0b408d7ba93240850d8678abb785b
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Sparrow/Assets/Scripts/Enemies/FSMBasic/PursueAction.asset
+++ b/Sparrow/Assets/Scripts/Enemies/FSMBasic/PursueAction.asset
@@ -12,10 +12,12 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: d54e8ea449cc5af4ca90a0065d00f741, type: 3}
   m_Name: PursueAction
   m_EditorClassIdentifier: 
-  detectionRadius: 5
-  moveSpeed: 3
-  safeDistance: 2
-  rayLength: 5
+  speed: 5
+  maxSpeed: 10
+  avoidanceForceMultiplier: 10
+  raySpacing: 10
+  minAvoidanceDistance: 2
+  cornerAvoidanceForceMultiplier: 20
   obstacleLayerMask:
     serializedVersion: 2
     m_Bits: 3072

--- a/Sparrow/Assets/Scripts/Enemies/FSMBasic/PursueAction.asset
+++ b/Sparrow/Assets/Scripts/Enemies/FSMBasic/PursueAction.asset
@@ -9,10 +9,15 @@ MonoBehaviour:
   m_GameObject: {fileID: 0}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: b4e57822786b114489c18524799fb964, type: 3}
-  m_Name: PlayerInRangeDecision
+  m_Script: {fileID: 11500000, guid: d54e8ea449cc5af4ca90a0065d00f741, type: 3}
+  m_Name: PursueAction
   m_EditorClassIdentifier: 
-  detectionRange: 10
-  detectionLayerMask:
+  detectionRadius: 5
+  moveSpeed: 3
+  safeDistance: 2
+  rayLength: 5
+  obstacleLayerMask:
     serializedVersion: 2
-    m_Bits: 7232
+    m_Bits: 3072
+  numberOfCheckDirections: 8
+  parallelOffsetDistance: 0.5

--- a/Sparrow/Assets/Scripts/Enemies/FSMBasic/PursueAction.asset.meta
+++ b/Sparrow/Assets/Scripts/Enemies/FSMBasic/PursueAction.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: c6f7a5916fb8e6a4cb51fdbf44cb9909
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Sparrow/Assets/Scripts/Enemies/FSMBasic/PursueState.asset
+++ b/Sparrow/Assets/Scripts/Enemies/FSMBasic/PursueState.asset
@@ -9,10 +9,9 @@ MonoBehaviour:
   m_GameObject: {fileID: 0}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: b4e57822786b114489c18524799fb964, type: 3}
-  m_Name: PlayerInRangeDecision
+  m_Script: {fileID: 11500000, guid: 20bda4313f62060489b2d74a29e569dd, type: 3}
+  m_Name: PursueState
   m_EditorClassIdentifier: 
-  detectionRange: 10
-  detectionLayerMask:
-    serializedVersion: 2
-    m_Bits: 7232
+  Action:
+  - {fileID: 11400000, guid: c6f7a5916fb8e6a4cb51fdbf44cb9909, type: 2}
+  Transitions: []

--- a/Sparrow/Assets/Scripts/Enemies/FSMBasic/PursueState.asset.meta
+++ b/Sparrow/Assets/Scripts/Enemies/FSMBasic/PursueState.asset.meta
@@ -2,7 +2,7 @@ fileFormatVersion: 2
 guid: bc5b51c68f3e3314bbbc20628a42d13e
 NativeFormatImporter:
   externalObjects: {}
-  mainObjectFileID: 11400000
+  mainObjectFileID: 0
   userData: 
   assetBundleName: 
   assetBundleVariant: 

--- a/Sparrow/Assets/Scripts/Enemies/FSMBasic/PursueState.asset.meta
+++ b/Sparrow/Assets/Scripts/Enemies/FSMBasic/PursueState.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: bc5b51c68f3e3314bbbc20628a42d13e
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Sparrow/Assets/Scripts/Enemies/FSMScripts/BasicEnemy/ChaseState.cs
+++ b/Sparrow/Assets/Scripts/Enemies/FSMScripts/BasicEnemy/ChaseState.cs
@@ -9,7 +9,7 @@ namespace FSM
     {
         private void OnEnable()
         {
-            //Action.Add(ScriptableObject.CreateInstance<ChaseAction>());
+
         }
     }
 }

--- a/Sparrow/Assets/Scripts/Enemies/FSMScripts/BasicEnemy/PursueAction.cs
+++ b/Sparrow/Assets/Scripts/Enemies/FSMScripts/BasicEnemy/PursueAction.cs
@@ -1,0 +1,104 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+
+namespace FSM
+{
+    [CreateAssetMenu(menuName = "FSM/Actions/PursueAction", fileName = "PursueAction")]
+    public class PursueAction : FSMAction
+    {
+        public float speed = 5f;
+        public float maxSpeed = 10f;
+        public float avoidanceForceMultiplier = 10f;
+        public float raySpacing = 10f; // Distance of rays
+        public float minAvoidanceDistance = 2f; // Minimum distance to maintain from obstacles
+        public float cornerAvoidanceForceMultiplier = 20f; // Stronger force for corner avoidance
+        public LayerMask obstacleLayerMask;
+
+        public override void Execute(BaseStateMachine stateMachine)
+        {
+            MonoBehaviour monoBehaviour = (MonoBehaviour)stateMachine;
+            Transform entityTransform = monoBehaviour.transform;
+            Rigidbody2D rb = monoBehaviour.GetComponent<Rigidbody2D>();
+
+            if (rb == null)
+            {
+                Debug.LogWarning("Rigidbody2D component not found on stateMachine");
+                return;
+            }
+
+            GameObject player = GameObject.FindGameObjectWithTag("Player");
+            if (player == null)
+            {
+                Debug.LogWarning("Player not found");
+                return;
+            }
+
+            Vector2 playerDirection = (player.transform.position - entityTransform.position).normalized;
+            Vector2 avoidanceForce = Vector2.zero;
+
+            // Use multiple rays for obstacle detection
+            int numberOfRays = 8; // Number of rays to cast
+            float angleStep = 360f / numberOfRays; // Full circle
+
+            for (int i = 0; i < numberOfRays; i++)
+            {
+                float angle = i * angleStep;
+                Vector2 rayDirection = Quaternion.Euler(0, 0, angle) * playerDirection;
+                RaycastHit2D hit = Physics2D.Raycast(entityTransform.position, rayDirection, raySpacing, obstacleLayerMask);
+
+                if (hit.collider != null)
+                {
+                    float distanceToObstacle = hit.distance;
+                    float distanceToMaintain = minAvoidanceDistance - distanceToObstacle;
+
+                    if (distanceToMaintain > 0)
+                    {
+                        // Avoid corners with stronger force
+                        Vector2 parallelDirection = Vector2.Perpendicular(hit.normal);
+                        if (Vector2.Dot(parallelDirection, playerDirection) < 0)
+                        {
+                            parallelDirection = -parallelDirection;
+                        }
+
+                        Vector2 avoidanceVector = parallelDirection * (distanceToMaintain * avoidanceForceMultiplier);
+                        avoidanceForce += avoidanceVector;
+
+                        // Draw debug rays for visualization
+                        Debug.DrawRay(entityTransform.position, rayDirection * hit.distance, Color.red);
+                        Debug.DrawRay(hit.point, parallelDirection * 2f, Color.green);
+                    }
+                }
+            }
+
+            // Check if the avoidance force is too strong, which might cause the enemy to get stuck
+            if (avoidanceForce.magnitude > maxSpeed)
+            {
+                avoidanceForce = avoidanceForce.normalized * maxSpeed;
+            }
+
+            // Apply avoidance force
+            rb.AddForce(avoidanceForce);
+
+            // Calculate desired velocity and ensure it does not exceed maxSpeed
+            Vector2 desiredVelocity = playerDirection * speed;
+            Vector2 newVelocity = rb.velocity + (desiredVelocity - rb.velocity) * Time.deltaTime;
+
+            if (newVelocity.magnitude > maxSpeed)
+            {
+                newVelocity = newVelocity.normalized * maxSpeed;
+            }
+
+            rb.velocity = newVelocity;
+
+            // Backup plan for stuck scenarios
+            if (rb.velocity.magnitude < 0.1f) // If the enemy is not moving
+            {
+                // Rotate randomly to escape the corner
+                float randomAngle = Random.Range(0f, 360f);
+                rb.velocity = new Vector2(Mathf.Cos(randomAngle), Mathf.Sin(randomAngle)) * speed;
+            }
+        }
+    }
+}

--- a/Sparrow/Assets/Scripts/Enemies/FSMScripts/BasicEnemy/PursueAction.cs.meta
+++ b/Sparrow/Assets/Scripts/Enemies/FSMScripts/BasicEnemy/PursueAction.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: d54e8ea449cc5af4ca90a0065d00f741
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Sparrow/Assets/Scripts/Enemies/FSMScripts/BasicEnemy/PursueState.cs
+++ b/Sparrow/Assets/Scripts/Enemies/FSMScripts/BasicEnemy/PursueState.cs
@@ -1,0 +1,15 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+namespace FSM
+{
+    [CreateAssetMenu(menuName = "FSM/PursueState", fileName = "PursueState")]
+    public class PursueState : BaseState
+    {
+        public override void Execute(BaseStateMachine machine)
+        {
+            // Implementation of behavior
+        }
+    }
+}

--- a/Sparrow/Assets/Scripts/Enemies/FSMScripts/BasicEnemy/PursueState.cs.meta
+++ b/Sparrow/Assets/Scripts/Enemies/FSMScripts/BasicEnemy/PursueState.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: f24fdcd61d18da04e805623d5405959f
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Sparrow/Assets/Scripts/MapGenerator/MapGeneratorWithSpawn.cs
+++ b/Sparrow/Assets/Scripts/MapGenerator/MapGeneratorWithSpawn.cs
@@ -63,7 +63,7 @@ public class MapGeneratorWithSpawn : MonoBehaviour
         CreateTileGroups();
         GenerateNoiseMap();
         GenerateMap();
-        CreateBorderColliders();      
+        CreateBorderColliders();
         SetTileColliders();
 
         FindSpwanPoints();
@@ -293,7 +293,8 @@ public class MapGeneratorWithSpawn : MonoBehaviour
         collider.points = new Vector2[] { pointA, pointB };
     }
 
-    void SetTileColliders() {
+    void SetTileColliders()
+    {
         //Sets Collieder to Specified GameObject Tiles
         foreach (var tileGroup in tileGroups.Values)
         {
@@ -366,9 +367,9 @@ public class MapGeneratorWithSpawn : MonoBehaviour
                 Vector2Int spawnPoint = spawnPoints[Random.Range(0, spawnPoints.Count)];
                 Vector3 spawnPosition = new Vector3(spawnPoint.x, spawnPoint.y, 0);
 
-            // Ensure enemies are spawned at least 'minDistanceFromCharacterSpawner' away from the character
-            float distanceFromPlayer = Vector3.Distance(spawnPosition, player.transform.position);
-            if (distanceFromPlayer < minDistanceFromPlayer)
+                // Ensure enemies are spawned at least 'minDistanceFromCharacterSpawner' away from the character
+                float distanceFromPlayer = Vector3.Distance(spawnPosition, player.transform.position);
+                if (distanceFromPlayer < minDistanceFromPlayer)
                 {
                     i--;
                     continue;
@@ -376,6 +377,7 @@ public class MapGeneratorWithSpawn : MonoBehaviour
 
                 GameObject enemy = Instantiate(enemyPrefab, spawnPosition, Quaternion.identity);
                 enemySpawned.TriggerEvent(enemy);
-            }            
+            }
         }
     }
+}

--- a/Sparrow/Assets/Scripts/MapGenerator/MapGeneratorWithSpawn.cs
+++ b/Sparrow/Assets/Scripts/MapGenerator/MapGeneratorWithSpawn.cs
@@ -47,7 +47,7 @@ public class MapGeneratorWithSpawn : MonoBehaviour
     //Tile Collider
     public GameObject[] gameObjectAddCollider;
 
-    //Enemy Spawning Positions
+    //Spawning Positions
     private List<Vector2Int> playerSpawnPoints = new List<Vector2Int>();
     private List<Vector2Int> spawnPoints = new List<Vector2Int>();
 
@@ -56,9 +56,8 @@ public class MapGeneratorWithSpawn : MonoBehaviour
     public Transform mapCenterTransform;
     public CinemachineCameraController cameraController;
 
-
-    //Activations on Start
-    void Start()
+    //Activations on LevelLoaded
+    public void OnLevelLoad(GameObject levelManager)
     {
         CreateTileset();
         CreateTileGroups();
@@ -69,7 +68,7 @@ public class MapGeneratorWithSpawn : MonoBehaviour
 
         FindSpwanPoints();
         SpawnPlayer();
-        SpawnEnemies();
+        SpawnEnemies(levelDefinition.enemiesToSpawn);
 
 
     }
@@ -313,7 +312,7 @@ public class MapGeneratorWithSpawn : MonoBehaviour
         Vector3 playerSpawnPosition = new Vector3(playerSpawnPoint.x, playerSpawnPoint.y, 0);
         GameObject playerSpawn = Instantiate(player, playerSpawnPosition, Quaternion.identity);
 
-       
+
 
         if (cameraController != null)
         {
@@ -358,10 +357,14 @@ public class MapGeneratorWithSpawn : MonoBehaviour
             return;
         }
 
-        for (int i = 0; i < numberOfEnemies; i++)
+        foreach (LevelDefinition.EnemyConfiguration enemyType in enemiesToSpawn)
         {
-            Vector2Int spawnPoint = spawnPoints[Random.Range(0, spawnPoints.Count)];
-            Vector3 spawnPosition = new Vector3(spawnPoint.x, spawnPoint.y, 0);
+            int numberOfEnemies = enemyType.Count;
+            GameObject enemyPrefab = enemyType.Enemy;
+            for (int i = 0; i < numberOfEnemies; i++)
+            {
+                Vector2Int spawnPoint = spawnPoints[Random.Range(0, spawnPoints.Count)];
+                Vector3 spawnPosition = new Vector3(spawnPoint.x, spawnPoint.y, 0);
 
             // Ensure enemies are spawned at least 'minDistanceFromCharacterSpawner' away from the character
             float distanceFromPlayer = Vector3.Distance(spawnPosition, player.transform.position);

--- a/Sparrow/Assets/Settings/Lit2DSceneTemplate.scenetemplate
+++ b/Sparrow/Assets/Settings/Lit2DSceneTemplate.scenetemplate
@@ -128,6 +128,8 @@ MonoBehaviour:
     instantiationMode: 1
   - dependency: {fileID: 2800000, guid: 5f2a108eb023faf43a809979fd3d38f2, type: 3}
     instantiationMode: 1
+  - dependency: {fileID: 11400000, guid: 2beee4ca3cbcfad4b83f26ea70d6c0e0, type: 2}
+    instantiationMode: 1
   templatePipeline: {fileID: 0}
   badge: {fileID: 0}
   addToDefaults: 1

--- a/Sparrow/Assets/Settings/Lit2DSceneTemplate.scenetemplate
+++ b/Sparrow/Assets/Settings/Lit2DSceneTemplate.scenetemplate
@@ -66,10 +66,6 @@ MonoBehaviour:
     the 2D Renderer in Universal RP.
   preview: {fileID: -3604256930052969394}
   dependencies:
-  - dependency: {fileID: 11400000, guid: 56b9e674f93afe648bf3a2871f72e44d, type: 2}
-    instantiationMode: 1
-  - dependency: {fileID: 11400000, guid: a70cd4b7380fd004e9f9e8a5e441ddab, type: 2}
-    instantiationMode: 1
   - dependency: {fileID: 11400000, guid: 116bf5fb3f66a75418355019acb7228a, type: 2}
     instantiationMode: 1
   - dependency: {fileID: 11400000, guid: b73fb2d53db29e846b2b4170cab601f7, type: 2}
@@ -82,8 +78,6 @@ MonoBehaviour:
     instantiationMode: 0
   - dependency: {fileID: 5743417108097213276, guid: 8294936f375755e46bb734b3c3af1913, type: 3}
     instantiationMode: 0
-  - dependency: {fileID: 11400000, guid: 7951c64df9968d24792219d7a48e486d, type: 2}
-    instantiationMode: 1
   - dependency: {fileID: 11400000, guid: d8ed48c2720aaa64d8e7a6961abaafca, type: 2}
     instantiationMode: 1
   - dependency: {fileID: 11400000, guid: b1edf3c5d1e23fc448ebc5d74f661a49, type: 2}
@@ -92,21 +86,19 @@ MonoBehaviour:
     instantiationMode: 0
   - dependency: {fileID: 248383343662709132, guid: 6b9d6f80cad33044893fbbf9221d52b1, type: 3}
     instantiationMode: 0
-  - dependency: {fileID: 11400000, guid: 67f66ad5bd87904468fe0eb354091ba1, type: 2}
+  - dependency: {fileID: 11400000, guid: c6f7a5916fb8e6a4cb51fdbf44cb9909, type: 2}
     instantiationMode: 1
   - dependency: {fileID: 8979340069536578346, guid: 09b108a04595b6540b97fc1ed5afdd6b, type: 3}
     instantiationMode: 0
   - dependency: {fileID: 2208619554058997048, guid: 04d9f6f7d5254bf47820ec348b06a317, type: 3}
     instantiationMode: 0
-  - dependency: {fileID: 11400000, guid: 20e3a69ecdff10d4fb334550918014e8, type: 2}
-    instantiationMode: 1
+  - dependency: {fileID: 7400000, guid: ed8b56d01da000b468b4898d4161cd34, type: 2}
+    instantiationMode: 0
   - dependency: {fileID: 1739139097824912367, guid: e6705a9387e6dc540b52c0d10860a8db, type: 3}
     instantiationMode: 0
   - dependency: {fileID: 2800000, guid: 81ac09d6afe02284986eda815454b342, type: 3}
     instantiationMode: 0
   - dependency: {fileID: 474650801237723220, guid: 06124022d7883c54998b6bcdbcf12a5a, type: 3}
-    instantiationMode: 0
-  - dependency: {fileID: 7400000, guid: ed8b56d01da000b468b4898d4161cd34, type: 2}
     instantiationMode: 0
   - dependency: {fileID: 11400000, guid: 414dfc9853bd0654daa1e3928b01376e, type: 2}
     instantiationMode: 1
@@ -122,19 +114,19 @@ MonoBehaviour:
     instantiationMode: 0
   - dependency: {fileID: 2800000, guid: 7d6931cb078d423419f636b5c80bbf4b, type: 3}
     instantiationMode: 0
-  - dependency: {fileID: 11400000, guid: 432663453bd6f49438f99859c08730ce, type: 2}
-    instantiationMode: 1
   - dependency: {fileID: 5896505433429229737, guid: f2f0ec9b45559d54fb267a5477aefb2a, type: 3}
     instantiationMode: 0
   - dependency: {fileID: 2800000, guid: b9d6f9731e290cc40ac247831a4e29a7, type: 3}
     instantiationMode: 0
   - dependency: {fileID: 6847842634037359419, guid: 9e7965dd074dd0a4abcb3864277b5d27, type: 3}
     instantiationMode: 0
-  - dependency: {fileID: 11400000, guid: acd30eeb1ac8e5a46add53b054ad9258, type: 2}
-    instantiationMode: 1
   - dependency: {fileID: 2800000, guid: 9ad5571e14ac03142bb2ebba94c1ac1a, type: 3}
     instantiationMode: 0
   - dependency: {fileID: 11400000, guid: 525f618103afe3d499e29e13d20c11bd, type: 2}
+    instantiationMode: 1
+  - dependency: {fileID: 11400000, guid: bc5b51c68f3e3314bbbc20628a42d13e, type: 2}
+    instantiationMode: 1
+  - dependency: {fileID: 2800000, guid: 5f2a108eb023faf43a809979fd3d38f2, type: 3}
     instantiationMode: 1
   templatePipeline: {fileID: 0}
   badge: {fileID: 0}

--- a/Sparrow/Packages/manifest.json
+++ b/Sparrow/Packages/manifest.json
@@ -1,5 +1,7 @@
 {
   "dependencies": {
+    "com.mixpanel.unity": "https://github.com/mixpanel/mixpanel-unity.git#master",
+    "com.unity.cinemachine": "2.10.1",
     "com.unity.collab-proxy": "2.4.3",
     "com.unity.feature.2d": "2.0.1",
     "com.unity.ide.rider": "3.0.28",
@@ -39,8 +41,6 @@
     "com.unity.modules.video": "1.0.0",
     "com.unity.modules.vr": "1.0.0",
     "com.unity.modules.wind": "1.0.0",
-    "com.unity.modules.xr": "1.0.0",
-
-    "com.mixpanel.unity": "https://github.com/mixpanel/mixpanel-unity.git#master"
+    "com.unity.modules.xr": "1.0.0"
   }
 }

--- a/Sparrow/Packages/packages-lock.json
+++ b/Sparrow/Packages/packages-lock.json
@@ -111,6 +111,15 @@
       },
       "url": "https://packages.unity.com"
     },
+    "com.unity.cinemachine": {
+      "version": "2.10.1",
+      "depth": 0,
+      "source": "registry",
+      "dependencies": {
+        "com.unity.test-framework": "1.1.31"
+      },
+      "url": "https://packages.unity.com"
+    },
     "com.unity.collab-proxy": {
       "version": "2.4.3",
       "depth": 0,


### PR DESCRIPTION
Fixed player spawner to not spawn in islands.

Update camera to use virtual camera from cinemachine that follows player.

Updated mapGenerator to turn individual sand and grass colliders into a single composite collider so enemies would not glitch through island. Also passed tags and layers form prefabs to composite collider.

Created a basic pursue action to reduce enemies getting stuck on islands (still needs more work but should be good enough for now).