### PR TITLE
Saving Player State Across Scenes

### DIFF
--- a/Sparrow/Assets/DroppableItems/Gold/Gold.prefab
+++ b/Sparrow/Assets/DroppableItems/Gold/Gold.prefab
@@ -30,7 +30,7 @@ Transform:
   serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 1090.479, y: 538.41, z: -6.1993785}
-  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_LocalScale: {x: 2, y: 2, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 0}
@@ -163,4 +163,4 @@ CircleCollider2D:
   m_UsedByComposite: 0
   m_Offset: {x: 0, y: 0}
   serializedVersion: 2
-  m_Radius: 0.08
+  m_Radius: 0.14943603

--- a/Sparrow/Assets/Prefabs/PlayerShipBase.prefab
+++ b/Sparrow/Assets/Prefabs/PlayerShipBase.prefab
@@ -142,6 +142,7 @@ GameObject:
   - component: {fileID: 3332890461431351674}
   - component: {fileID: -2631711962479061696}
   - component: {fileID: 2948438652008200204}
+  - component: {fileID: 6148248609884579871}
   m_Layer: 6
   m_Name: PlayerShipBase
   m_TagString: Player
@@ -431,7 +432,36 @@ MonoBehaviour:
   healthChanged: {fileID: 11400000, guid: 525f618103afe3d499e29e13d20c11bd, type: 2}
   onDeath: {fileID: 0}
   damageSourceTags: 0100000002000000
-  HitPoints: 10
+  hitPoints: 5
+  isPlayer: 1
+--- !u!114 &6148248609884579871
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6847842634037359419}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: d71e0b6cc8f7e5f4f85b219916a62af4, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  gameEvent: {fileID: 11400000, guid: a2ea2112d92e16a4094caba09b6161b2, type: 2}
+  onEventTriggered:
+    m_PersistentCalls:
+      m_Calls:
+      - m_Target: {fileID: 2948438652008200204}
+        m_TargetAssemblyTypeName: HealthManager, Assembly-CSharp
+        m_MethodName: OnLevelComplete
+        m_Mode: 0
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
 --- !u!1 &7597696367023192810
 GameObject:
   m_ObjectHideFlags: 0

--- a/Sparrow/Assets/Scenes/Battlefield.unity
+++ b/Sparrow/Assets/Scenes/Battlefield.unity
@@ -524,6 +524,7 @@ MonoBehaviour:
   totalEnemies: 0
   levelDefinition: {fileID: 0}
   LevelLoaded: {fileID: 11400000, guid: 2beee4ca3cbcfad4b83f26ea70d6c0e0, type: 2}
+  LevelCompleted: {fileID: 11400000, guid: a2ea2112d92e16a4094caba09b6161b2, type: 2}
 --- !u!114 &215481228
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -717,10 +718,10 @@ RectTransform:
   - {fileID: 825750299}
   m_Father: {fileID: 64053596}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0.5, y: 0.5}
-  m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 100, y: 100}
+  m_AnchorMin: {x: 0, y: 1}
+  m_AnchorMax: {x: 0, y: 1}
+  m_AnchoredPosition: {x: 960, y: -540}
+  m_SizeDelta: {x: 1920, y: 1080}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!1 &825750298
 GameObject:
@@ -1725,6 +1726,8 @@ GameObject:
   - component: {fileID: 1899862653}
   - component: {fileID: 1899862655}
   - component: {fileID: 1899862656}
+  - component: {fileID: 1899862657}
+  - component: {fileID: 1899862658}
   m_Layer: 0
   m_Name: PlayerStatus
   m_TagString: Untagged
@@ -1809,6 +1812,62 @@ MonoBehaviour:
       - m_Target: {fileID: 1899862653}
         m_TargetAssemblyTypeName: PlayerStatus, Assembly-CSharp
         m_MethodName: OnHealthUpdate
+        m_Mode: 0
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
+--- !u!114 &1899862657
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1899862652}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: d71e0b6cc8f7e5f4f85b219916a62af4, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  gameEvent: {fileID: 11400000, guid: a2ea2112d92e16a4094caba09b6161b2, type: 2}
+  onEventTriggered:
+    m_PersistentCalls:
+      m_Calls:
+      - m_Target: {fileID: 1899862653}
+        m_TargetAssemblyTypeName: PlayerStatus, Assembly-CSharp
+        m_MethodName: OnLevelComplete
+        m_Mode: 0
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
+--- !u!114 &1899862658
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1899862652}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: d71e0b6cc8f7e5f4f85b219916a62af4, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  gameEvent: {fileID: 11400000, guid: 2beee4ca3cbcfad4b83f26ea70d6c0e0, type: 2}
+  onEventTriggered:
+    m_PersistentCalls:
+      m_Calls:
+      - m_Target: {fileID: 1899862653}
+        m_TargetAssemblyTypeName: PlayerStatus, Assembly-CSharp
+        m_MethodName: OnLevelLoad
         m_Mode: 0
         m_Arguments:
           m_ObjectArgument: {fileID: 0}

--- a/Sparrow/Assets/Scripts/Enemies/FSMScripts/BasicEnemy/PursueAction.cs
+++ b/Sparrow/Assets/Scripts/Enemies/FSMScripts/BasicEnemy/PursueAction.cs
@@ -99,6 +99,10 @@ namespace FSM
                 float randomAngle = Random.Range(0f, 360f);
                 rb.velocity = new Vector2(Mathf.Cos(randomAngle), Mathf.Sin(randomAngle)) * speed;
             }
+
+            // Ensure that enemy is always pointed in the direction of movement
+            // 90f offset due to sprite facing "up" (90 degrees) by default
+            rb.rotation = (Mathf.Atan2(rb.velocity.y, rb.velocity.x) * Mathf.Rad2Deg) - 90f;
         }
     }
 }

--- a/Sparrow/Assets/Scripts/Events/LevelCompleted.asset
+++ b/Sparrow/Assets/Scripts/Events/LevelCompleted.asset
@@ -1,0 +1,14 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: e07af557ca8d0ce418ddd5ef736576f4, type: 3}
+  m_Name: LevelCompleted
+  m_EditorClassIdentifier: 

--- a/Sparrow/Assets/Scripts/Events/LevelCompleted.asset.meta
+++ b/Sparrow/Assets/Scripts/Events/LevelCompleted.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: a2ea2112d92e16a4094caba09b6161b2
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Sparrow/Assets/Scripts/GameState/GlobalVariables.cs
+++ b/Sparrow/Assets/Scripts/GameState/GlobalVariables.cs
@@ -33,4 +33,9 @@ public static class GlobalVariables
         }
         _variablesDictionary[key] = value;
     }
+
+    public static void ClearAll()
+    {
+        _variablesDictionary.Clear();
+    }
 }

--- a/Sparrow/Assets/Scripts/GameState/HealthManager.cs
+++ b/Sparrow/Assets/Scripts/GameState/HealthManager.cs
@@ -13,13 +13,29 @@ public class HealthManager : MonoBehaviour
     public GameEvent healthChanged;
     public GameEvent onDeath;
     public List<DamageSourceTag> damageSourceTags;
-    public int HitPoints = 5;
+    public int hitPoints = 5;
+    public bool isPlayer = false;
+    
+    private static string PLAYER_HEALTH = "Player Health";
 
     void OnEnable()
     {
+        if (isPlayer && GlobalVariables.Get<int>(PLAYER_HEALTH) != 0)
+        {
+            hitPoints = GlobalVariables.Get<int>(PLAYER_HEALTH);
+        }
+
         if (healthChanged != null)
         {
             healthChanged.TriggerEvent(gameObject);
+        }
+    }
+
+    public void OnLevelComplete(GameObject obj)
+    {
+        if (isPlayer)
+        {
+            GlobalVariables.Set(PLAYER_HEALTH, hitPoints);
         }
     }
 
@@ -35,7 +51,7 @@ public class HealthManager : MonoBehaviour
                 {
                     damage = other.gameObject.GetComponent<CannonballLogic>().attackStrength;
                 }
-                HitPoints -= damage;
+                hitPoints -= damage;
                 if (healthChanged != null)
                 {
                     healthChanged.TriggerEvent(gameObject);
@@ -43,7 +59,7 @@ public class HealthManager : MonoBehaviour
                 break;
             }
         }
-        if (HitPoints <= 0)
+        if (hitPoints <= 0)
         {
             if (onDeath != null)
             {

--- a/Sparrow/Assets/Scripts/GameState/LevelManager.cs
+++ b/Sparrow/Assets/Scripts/GameState/LevelManager.cs
@@ -9,6 +9,7 @@ public class LevelManager : MonoBehaviour
 
     public static string NEXT_LEVEL = "Next Level";
     public GameEvent LevelLoaded;
+    public GameEvent LevelCompleted;
     
     private List<GameObject> _enemies = new List<GameObject>();
     private bool _levelCleared = false;
@@ -30,12 +31,6 @@ public class LevelManager : MonoBehaviour
         SceneManager.LoadScene("Scenes/Battlefield");
     }
 
-
-    void Update()
-    {
-
-    }
-
     public void OnEnemySpawn(GameObject eventSource)
     {
         _enemies.Add(eventSource);
@@ -52,6 +47,7 @@ public class LevelManager : MonoBehaviour
             _levelCleared = true;
             Debug.Log("Level Cleared");
             // TODO: Add timer or some mechanism to gate this so player has time to collect loot
+            LevelCompleted.TriggerEvent(gameObject);
             LoadNextLevel();
         }
     }

--- a/Sparrow/Assets/Scripts/GameState/PlayerStatus.cs
+++ b/Sparrow/Assets/Scripts/GameState/PlayerStatus.cs
@@ -6,15 +6,36 @@ public class PlayerStatus : MonoBehaviour
     public int totalGold = 0;
     public Text currencyText;
     public Text healthText;
+
+    private static string CURRENT_GOLD = "Player Gold";
+
     public void OnGoldCollection(GameObject gold)
     {
-        totalGold += gold.GetComponent<Gold>().value;
-        currencyText.text = totalGold.ToString();
+        UpdateGold(gold.GetComponent<Gold>().value);
     }
 
     public void OnHealthUpdate(GameObject player)
     {
-        int health = player.GetComponent<HealthManager>().HitPoints;
+        int health = player.GetComponent<HealthManager>().hitPoints;
         healthText.text = health.ToString();
+    }
+
+    public void OnLevelLoad(GameObject levelDef)
+    {
+        if (GlobalVariables.Get<int>(CURRENT_GOLD) != 0)
+        {
+            UpdateGold(GlobalVariables.Get<int>(CURRENT_GOLD));
+        }
+    }
+
+    public void OnLevelComplete(GameObject obj)
+    {
+        GlobalVariables.Set(CURRENT_GOLD, totalGold);
+    }
+
+    private void UpdateGold(int amount)
+    {
+        totalGold += amount;
+        currencyText.text = totalGold.ToString();
     }
 }

--- a/Sparrow/Assets/Scripts/Levels/Level3.asset
+++ b/Sparrow/Assets/Scripts/Levels/Level3.asset
@@ -10,10 +10,10 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 9cfcda6365f4eae4396f1f23e45bb59a, type: 3}
-  m_Name: Level2
+  m_Name: Level3
   m_EditorClassIdentifier: 
-  name: 'Level 2: The Squeakquel'
+  name: 'Level 3: Tokyo Drift'
   enemiesToSpawn:
   - Enemy: {fileID: 1739139097824912367, guid: e6705a9387e6dc540b52c0d10860a8db, type: 3}
-    Count: 5
-  nextLevel: {fileID: 11400000, guid: 3d385fbc7e76a014bab11b3c3fbdbb80, type: 2}
+    Count: 10
+  nextLevel: {fileID: 0}

--- a/Sparrow/Assets/Scripts/Levels/Level3.asset.meta
+++ b/Sparrow/Assets/Scripts/Levels/Level3.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 3d385fbc7e76a014bab11b3c3fbdbb80
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Sparrow/Assets/Scripts/Menus/TitleMenuLogic.cs
+++ b/Sparrow/Assets/Scripts/Menus/TitleMenuLogic.cs
@@ -15,6 +15,7 @@ public class TitleMenuLogic : MonoBehaviour
 
     public void loadNewGame()
     {
+        GlobalVariables.ClearAll();
         GlobalVariables.Set(LevelManager.NEXT_LEVEL, gameStartLevel);
         SceneManager.LoadScene(newGameScene);
     }

--- a/Sparrow/Assets/Scripts/Player/ShipConfiguration.cs
+++ b/Sparrow/Assets/Scripts/Player/ShipConfiguration.cs
@@ -10,10 +10,18 @@ public class ShipConfiguration : MonoBehaviour
     public Rigidbody2D shipRb;
     private List<GameObject> _cannons = new();
 
+    private static string PLAYER_CANNON_DEF = "Player Cannon Configuration";
+
     // Start is called before the first frame update
     void Start()
     {
-        
+        // If we have transitioned from previous screen, use the players existing cannon setup, otherwise
+        // reset to default (definied in editor Player ship prefab)
+        if (GlobalVariables.Get<Cannon[]>(PLAYER_CANNON_DEF) != null)
+        {
+            cannonDefs = GlobalVariables.Get<Cannon[]>(PLAYER_CANNON_DEF);
+        }
+
         float _maxDistance = 0f;
         for (int i = 0; i < cannonDefs.Length; i++)
         {
@@ -43,5 +51,10 @@ public class ShipConfiguration : MonoBehaviour
             CannonContainer container = _cannons[i].GetComponent<CannonContainer>();
             container.cannon.GetComponent<CannonStateMachine>().SetTarget(target);
         }
+    }
+
+    public void SaveConfiguration()
+    {
+        GlobalVariables.Set(PLAYER_CANNON_DEF, cannonDefs);
     }
 }

--- a/Sparrow/Assets/Settings/Lit2DSceneTemplate.scenetemplate
+++ b/Sparrow/Assets/Settings/Lit2DSceneTemplate.scenetemplate
@@ -94,6 +94,8 @@ MonoBehaviour:
     instantiationMode: 0
   - dependency: {fileID: 7400000, guid: ed8b56d01da000b468b4898d4161cd34, type: 2}
     instantiationMode: 0
+  - dependency: {fileID: 11400000, guid: a2ea2112d92e16a4094caba09b6161b2, type: 2}
+    instantiationMode: 1
   - dependency: {fileID: 1739139097824912367, guid: e6705a9387e6dc540b52c0d10860a8db, type: 3}
     instantiationMode: 0
   - dependency: {fileID: 2800000, guid: 81ac09d6afe02284986eda815454b342, type: 3}


### PR DESCRIPTION
1. Added save and Load to GlobalVariables for Player Cannons, Health, and Gold
2. Cleared GlobalVariables on Title Screen load.
3. Added rotation to enemy PursueAction.
4. Set Player Status display UI anchor to top-left in the canvas so that elements are properly placed.