### PR TITLE
Added too expensive text color to shop

### DIFF
--- a/Sparrow/Assets/Scenes/Menus/Shop.unity
+++ b/Sparrow/Assets/Scenes/Menus/Shop.unity
@@ -494,7 +494,7 @@ MonoBehaviour:
   - {fileID: 11400000, guid: 6d96aeaa8878ccd40a5b355020c1e756, type: 2}
   - {fileID: 11400000, guid: 3aad6bc5957e7d2409bf9cd3d8a99a06, type: 2}
   - {fileID: 11400000, guid: a3f06560a6a606846a45b0ed33328706, type: 2}
-  totalGold: 100
+  totalGold: 0
   playerCannons: []
   goldText: {fileID: 591353964}
   cannonsLoadedEvent: {fileID: 11400000, guid: cb06ff2c14693314286535e3d7140af5, type: 2}
@@ -596,7 +596,7 @@ MonoBehaviour:
   m_TargetGraphic: {fileID: 1519055756}
   m_HandleRect: {fileID: 1519055755}
   m_Direction: 0
-  m_Value: 1
+  m_Value: 0
   m_Size: 1
   m_NumberOfSteps: 0
   m_OnValueChanged:
@@ -779,6 +779,9 @@ MonoBehaviour:
   ShopManager: {fileID: 332796622}
   cost: 0
   displayIcon: {fileID: 1168265797}
+  tooExpensiveColor:
+    serializedVersion: 2
+    rgba: 3777828723
 --- !u!114 &719144356
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -1487,6 +1490,9 @@ MonoBehaviour:
   ShopManager: {fileID: 332796622}
   cost: 0
   displayIcon: {fileID: 99992159}
+  tooExpensiveColor:
+    serializedVersion: 2
+    rgba: 3777828723
 --- !u!114 &1394122283
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -2292,6 +2298,9 @@ MonoBehaviour:
   ShopManager: {fileID: 332796622}
   cost: 0
   displayIcon: {fileID: 1603604993}
+  tooExpensiveColor:
+    serializedVersion: 2
+    rgba: 3777828723
 --- !u!114 &1935512919
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/Sparrow/Assets/Scripts/Shop/ButtonInfo.cs
+++ b/Sparrow/Assets/Scripts/Shop/ButtonInfo.cs
@@ -8,6 +8,12 @@ public class ButtonInfo : MonoBehaviour
     public GameObject ShopManager;
     public int cost;
     public Image displayIcon;
+    public Color32 tooExpensiveColor;
+
+    void OnEnable()
+    {
+        tooExpensiveColor = new Color32(115, 23, 45, 225);
+    }
 
     public void CannonsLoaded(GameObject source)
     {
@@ -32,6 +38,7 @@ public class ButtonInfo : MonoBehaviour
         int totalGold = ShopManager.GetComponent<ShopManagerLogic>().totalGold;
         if (totalGold < cost)
         {
+            PriceText.color = tooExpensiveColor;
             SuppressButton();
         }
     }


### PR DESCRIPTION
1. Logic to change color to a partial transparent red when player currency is less than cost of a new cannon
2. Reset the default Total Gold value back to 0 as this was loading player at 100 gold on the first shop visit