### PR TITLE
Fix (?) Bug with enemy remaining count

### DIFF
--- a/Sparrow/Assets/Prefabs/CloseEnemies/Shark.prefab
+++ b/Sparrow/Assets/Prefabs/CloseEnemies/Shark.prefab
@@ -156,7 +156,7 @@ SpriteRenderer:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 8532208803328321596}
-  m_Enabled: 1
+  m_Enabled: 0
   m_CastShadows: 0
   m_ReceiveShadows: 0
   m_DynamicOccludee: 1

--- a/Sparrow/Assets/Scenes/Menus/Credits.unity
+++ b/Sparrow/Assets/Scenes/Menus/Credits.unity
@@ -1065,9 +1065,9 @@ MonoBehaviour:
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
-  m_text: "Bryan Yee\n\nCole Ritmire\n\t-UI/UX designer\n\t-Lead Game Designer\n\t-System
-    Analyst\n\t-Junior Coding Extraordinaire\n\nJacob Robbins\n\nKeith Miller\n\t-Lead
-    System Designer\n\nMichael Prather\n\t-System Designer\n\nNick Khan"
+  m_text: "Bryan Yee\n\nCole Ritmire\n\tUI/UX designer\n\tLead Game Designer\n\tSystem
+    Analyst\n\tJunior Coding Extraordinaire\n\nJacob Robbins\n\nKeith Miller - mkm2010@gmail.com\n\tLead
+    System Designer\n\nMichael Prather\n\tSystem Designer\n\nNick Khan"
   m_isRightToLeft: 0
   m_fontAsset: {fileID: 11400000, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
   m_sharedMaterial: {fileID: 2180264, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}

--- a/Sparrow/Assets/Scripts/GameState/LevelManager.cs
+++ b/Sparrow/Assets/Scripts/GameState/LevelManager.cs
@@ -60,8 +60,8 @@ public class LevelManager : MonoBehaviour
 
     public void OnEnemyDeath(GameObject eventSource)
     {
-        _enemies.RemoveAll(enemy => ReferenceEquals(enemy, eventSource));
-        totalEnemies--;
+        int removed = _enemies.RemoveAll(enemy => ReferenceEquals(enemy, eventSource));
+        totalEnemies -= removed;
         UpdateEnemyCountText();
         Metrics.RegisterEnemyKilled(eventSource);
         if (!_levelCleared && _enemies.Count <= 0)


### PR DESCRIPTION
1. Level manager now only decrements enemies remaining when there is an enemy to remove (case where enemy death triggers twice for some reason)
2. Added my (Keith's) contact info to the credits screen
3. Hid the shark sprite renderer to fix visual bug where it looks like they're sitting on top of themselves