### PR TITLE
Fixing bug with shop price updating

### DIFF
--- a/Sparrow/Assets/Scripts/Shop/ButtonInfo.cs
+++ b/Sparrow/Assets/Scripts/Shop/ButtonInfo.cs
@@ -34,6 +34,7 @@ public class ButtonInfo : MonoBehaviour
 
     public void OnItemPurchase(GameObject source)
     {
+        CheckIfEnoughGoldToBuy();
         SuppressButton();
     }
 


### PR DESCRIPTION
1. Fixing bug when buying item, the price display color was not updating when the total gold drops below item cost