### PR TITLE
Fixing Targeting Bug, Explosion damage

### DIFF
--- a/Sparrow/Assets/Prefabs/CannonEnemies/CannonEnemy.prefab
+++ b/Sparrow/Assets/Prefabs/CannonEnemies/CannonEnemy.prefab
@@ -98,7 +98,6 @@ GameObject:
   - component: {fileID: 605418080969120408}
   - component: {fileID: 974075676751969829}
   - component: {fileID: 7149692812225392152}
-  - component: {fileID: 7260513372849428912}
   - component: {fileID: -7841565561910008616}
   - component: {fileID: 5823271381437379983}
   m_Layer: 8
@@ -222,41 +221,6 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   _initialState: {fileID: 11400000, guid: 5a3efcc2723ffe04588fc969b288c524, type: 2}
---- !u!58 &7260513372849428912
-CircleCollider2D:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1739139097824912367}
-  m_Enabled: 1
-  m_Density: 1
-  m_Material: {fileID: 0}
-  m_IncludeLayers:
-    serializedVersion: 2
-    m_Bits: 0
-  m_ExcludeLayers:
-    serializedVersion: 2
-    m_Bits: 0
-  m_LayerOverridePriority: 0
-  m_ForceSendLayers:
-    serializedVersion: 2
-    m_Bits: 4294967295
-  m_ForceReceiveLayers:
-    serializedVersion: 2
-    m_Bits: 4294967295
-  m_ContactCaptureLayers:
-    serializedVersion: 2
-    m_Bits: 4294967295
-  m_CallbackLayers:
-    serializedVersion: 2
-    m_Bits: 4294967295
-  m_IsTrigger: 1
-  m_UsedByEffector: 0
-  m_UsedByComposite: 0
-  m_Offset: {x: 0, y: 0}
-  serializedVersion: 2
-  m_Radius: 1.85
 --- !u!114 &-7841565561910008616
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/Sparrow/Assets/Prefabs/CannonEnemies/MultiCannonEnemy.prefab
+++ b/Sparrow/Assets/Prefabs/CannonEnemies/MultiCannonEnemy.prefab
@@ -12,7 +12,6 @@ GameObject:
   - component: {fileID: 1102838177309603143}
   - component: {fileID: -4682805084416169749}
   - component: {fileID: 6767940278527814642}
-  - component: {fileID: 2296189469135499066}
   - component: {fileID: 2228696996398852990}
   - component: {fileID: 8215240886526113579}
   - component: {fileID: -4116276440994432840}
@@ -158,41 +157,6 @@ CapsuleCollider2D:
   m_Offset: {x: 0.04, y: 0}
   m_Size: {x: 2.09, y: 4.67}
   m_Direction: 0
---- !u!58 &2296189469135499066
-CircleCollider2D:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 769043245617342556}
-  m_Enabled: 1
-  m_Density: 1
-  m_Material: {fileID: 0}
-  m_IncludeLayers:
-    serializedVersion: 2
-    m_Bits: 0
-  m_ExcludeLayers:
-    serializedVersion: 2
-    m_Bits: 0
-  m_LayerOverridePriority: 0
-  m_ForceSendLayers:
-    serializedVersion: 2
-    m_Bits: 4294967295
-  m_ForceReceiveLayers:
-    serializedVersion: 2
-    m_Bits: 4294967295
-  m_ContactCaptureLayers:
-    serializedVersion: 2
-    m_Bits: 4294967295
-  m_CallbackLayers:
-    serializedVersion: 2
-    m_Bits: 4294967295
-  m_IsTrigger: 1
-  m_UsedByEffector: 0
-  m_UsedByComposite: 0
-  m_Offset: {x: 0, y: 0}
-  serializedVersion: 2
-  m_Radius: 2
 --- !u!114 &2228696996398852990
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -212,6 +176,7 @@ MonoBehaviour:
   hitPoints: 25
   isPlayer: 0
   model: {fileID: 769043245617342556}
+  additionalDashIFrame: 0
   hitInvulnDurationSeconds: 0
   invulnDeltaTime: 0
 --- !u!114 &8215240886526113579

--- a/Sparrow/Assets/Prefabs/CloseEnemies/MeleeEnemy.prefab
+++ b/Sparrow/Assets/Prefabs/CloseEnemies/MeleeEnemy.prefab
@@ -225,7 +225,6 @@ GameObject:
   - component: {fileID: -1270665060887341487}
   - component: {fileID: 8914662128600569659}
   - component: {fileID: -6941661169420318117}
-  - component: {fileID: -9205748010682149557}
   - component: {fileID: 7634314924459837451}
   m_Layer: 8
   m_Name: MeleeEnemy
@@ -366,41 +365,6 @@ MonoBehaviour:
   - {fileID: 11400000, guid: 42d809bc0ca08194689935d656157514, type: 2}
   cannonTemplate: {fileID: 248383343662709132, guid: 6b9d6f80cad33044893fbbf9221d52b1, type: 3}
   shipRb: {fileID: -8151760289926994441}
---- !u!58 &-9205748010682149557
-CircleCollider2D:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 8678284688648251416}
-  m_Enabled: 1
-  m_Density: 1
-  m_Material: {fileID: 0}
-  m_IncludeLayers:
-    serializedVersion: 2
-    m_Bits: 0
-  m_ExcludeLayers:
-    serializedVersion: 2
-    m_Bits: 0
-  m_LayerOverridePriority: 0
-  m_ForceSendLayers:
-    serializedVersion: 2
-    m_Bits: 4294967295
-  m_ForceReceiveLayers:
-    serializedVersion: 2
-    m_Bits: 4294967295
-  m_ContactCaptureLayers:
-    serializedVersion: 2
-    m_Bits: 4294967295
-  m_CallbackLayers:
-    serializedVersion: 2
-    m_Bits: 4294967295
-  m_IsTrigger: 1
-  m_UsedByEffector: 0
-  m_UsedByComposite: 0
-  m_Offset: {x: 0, y: 0}
-  serializedVersion: 2
-  m_Radius: 1
 --- !u!114 &7634314924459837451
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/Sparrow/Assets/Prefabs/ExplosiveEnemies/ExplosiveEnemy.prefab
+++ b/Sparrow/Assets/Prefabs/ExplosiveEnemies/ExplosiveEnemy.prefab
@@ -122,7 +122,6 @@ GameObject:
   - component: {fileID: -1325999024209347325}
   - component: {fileID: 9034353145717550610}
   - component: {fileID: 7017518644806560652}
-  - component: {fileID: -2357433500948100505}
   - component: {fileID: -1919192721383592508}
   m_Layer: 8
   m_Name: ExplosiveEnemy
@@ -263,41 +262,6 @@ MonoBehaviour:
   - {fileID: 11400000, guid: 372bdaa4f76fb7042884d03d332caeef, type: 2}
   cannonTemplate: {fileID: 248383343662709132, guid: 6b9d6f80cad33044893fbbf9221d52b1, type: 3}
   shipRb: {fileID: 4585488000128103596}
---- !u!58 &-2357433500948100505
-CircleCollider2D:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2113082560015712493}
-  m_Enabled: 1
-  m_Density: 1
-  m_Material: {fileID: 0}
-  m_IncludeLayers:
-    serializedVersion: 2
-    m_Bits: 0
-  m_ExcludeLayers:
-    serializedVersion: 2
-    m_Bits: 0
-  m_LayerOverridePriority: 0
-  m_ForceSendLayers:
-    serializedVersion: 2
-    m_Bits: 4294967295
-  m_ForceReceiveLayers:
-    serializedVersion: 2
-    m_Bits: 4294967295
-  m_ContactCaptureLayers:
-    serializedVersion: 2
-    m_Bits: 4294967295
-  m_CallbackLayers:
-    serializedVersion: 2
-    m_Bits: 4294967295
-  m_IsTrigger: 1
-  m_UsedByEffector: 0
-  m_UsedByComposite: 0
-  m_Offset: {x: 0, y: 0}
-  serializedVersion: 2
-  m_Radius: 1.72
 --- !u!114 &-1919192721383592508
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/Sparrow/Assets/Prefabs/FlamethrowerEnemies/FlamethrowerEnemy.prefab
+++ b/Sparrow/Assets/Prefabs/FlamethrowerEnemies/FlamethrowerEnemy.prefab
@@ -4984,7 +4984,6 @@ GameObject:
   - component: {fileID: 2803948586991084623}
   - component: {fileID: 4332703334164343706}
   - component: {fileID: 605418080969120408}
-  - component: {fileID: 7260513372849428912}
   - component: {fileID: 974075676751969829}
   - component: {fileID: 7149692812225392152}
   - component: {fileID: -7841565561910008616}
@@ -5077,41 +5076,6 @@ CapsuleCollider2D:
   m_Offset: {x: 0, y: -0.051427245}
   m_Size: {x: 2, y: 4.06}
   m_Direction: 0
---- !u!58 &7260513372849428912
-CircleCollider2D:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1739139097824912367}
-  m_Enabled: 1
-  m_Density: 1
-  m_Material: {fileID: 0}
-  m_IncludeLayers:
-    serializedVersion: 2
-    m_Bits: 0
-  m_ExcludeLayers:
-    serializedVersion: 2
-    m_Bits: 0
-  m_LayerOverridePriority: 0
-  m_ForceSendLayers:
-    serializedVersion: 2
-    m_Bits: 4294967295
-  m_ForceReceiveLayers:
-    serializedVersion: 2
-    m_Bits: 4294967295
-  m_ContactCaptureLayers:
-    serializedVersion: 2
-    m_Bits: 4294967295
-  m_CallbackLayers:
-    serializedVersion: 2
-    m_Bits: 4294967295
-  m_IsTrigger: 1
-  m_UsedByEffector: 0
-  m_UsedByComposite: 0
-  m_Offset: {x: 0, y: 0}
-  serializedVersion: 2
-  m_Radius: 1.85
 --- !u!114 &974075676751969829
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/Sparrow/Assets/Prefabs/KrakenBoss/BarrelCannonPrefab.prefab
+++ b/Sparrow/Assets/Prefabs/KrakenBoss/BarrelCannonPrefab.prefab
@@ -12,7 +12,6 @@ GameObject:
   - component: {fileID: 5824185205919274231}
   - component: {fileID: -395314887558968486}
   - component: {fileID: -6142852984876472351}
-  - component: {fileID: -563183322832961249}
   - component: {fileID: -8001441464884594390}
   - component: {fileID: 3215271099032546087}
   - component: {fileID: 910944652587833793}
@@ -154,41 +153,6 @@ CapsuleCollider2D:
   m_Offset: {x: 0, y: 0}
   m_Size: {x: 2.46, y: 2.46}
   m_Direction: 0
---- !u!58 &-563183322832961249
-CircleCollider2D:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 3885092195304047416}
-  m_Enabled: 1
-  m_Density: 1
-  m_Material: {fileID: 0}
-  m_IncludeLayers:
-    serializedVersion: 2
-    m_Bits: 0
-  m_ExcludeLayers:
-    serializedVersion: 2
-    m_Bits: 0
-  m_LayerOverridePriority: 0
-  m_ForceSendLayers:
-    serializedVersion: 2
-    m_Bits: 4294967295
-  m_ForceReceiveLayers:
-    serializedVersion: 2
-    m_Bits: 4294967295
-  m_ContactCaptureLayers:
-    serializedVersion: 2
-    m_Bits: 4294967295
-  m_CallbackLayers:
-    serializedVersion: 2
-    m_Bits: 4294967295
-  m_IsTrigger: 1
-  m_UsedByEffector: 0
-  m_UsedByComposite: 0
-  m_Offset: {x: 0, y: 0}
-  serializedVersion: 2
-  m_Radius: 2
 --- !u!114 &-8001441464884594390
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -208,6 +172,7 @@ MonoBehaviour:
   hitPoints: 5
   isPlayer: 0
   model: {fileID: 0}
+  additionalDashIFrame: 0
   hitInvulnDurationSeconds: 0
   invulnDeltaTime: 0
 --- !u!114 &3215271099032546087

--- a/Sparrow/Assets/Prefabs/KrakenBoss/Kraken2.prefab
+++ b/Sparrow/Assets/Prefabs/KrakenBoss/Kraken2.prefab
@@ -265,8 +265,13 @@ MonoBehaviour:
   healthChanged: {fileID: 0}
   onDeath: {fileID: 11400000, guid: 414dfc9853bd0654daa1e3928b01376e, type: 2}
   damageSourceTags: 00000000
+  maxHealth: 0
   hitPoints: 5
   isPlayer: 0
+  model: {fileID: 0}
+  additionalDashIFrame: 0
+  hitInvulnDurationSeconds: 0
+  invulnDeltaTime: 0
 --- !u!114 &6337516722564690523
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -311,7 +316,6 @@ GameObject:
   - component: {fileID: 6998928770152645900}
   - component: {fileID: 4678754082690815350}
   - component: {fileID: 8689071490316621584}
-  - component: {fileID: 2858533961949176842}
   - component: {fileID: 8700169133995922697}
   - component: {fileID: 7964350986800119521}
   - component: {fileID: 3030936961560080983}
@@ -461,41 +465,6 @@ CapsuleCollider2D:
   m_Offset: {x: 0, y: 0}
   m_Size: {x: 5, y: 6}
   m_Direction: 0
---- !u!58 &2858533961949176842
-CircleCollider2D:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1011234398079243751}
-  m_Enabled: 1
-  m_Density: 1
-  m_Material: {fileID: 0}
-  m_IncludeLayers:
-    serializedVersion: 2
-    m_Bits: 0
-  m_ExcludeLayers:
-    serializedVersion: 2
-    m_Bits: 0
-  m_LayerOverridePriority: 0
-  m_ForceSendLayers:
-    serializedVersion: 2
-    m_Bits: 4294967295
-  m_ForceReceiveLayers:
-    serializedVersion: 2
-    m_Bits: 4294967295
-  m_ContactCaptureLayers:
-    serializedVersion: 2
-    m_Bits: 4294967295
-  m_CallbackLayers:
-    serializedVersion: 2
-    m_Bits: 4294967295
-  m_IsTrigger: 1
-  m_UsedByEffector: 0
-  m_UsedByComposite: 0
-  m_Offset: {x: 0, y: 0}
-  serializedVersion: 2
-  m_Radius: 3
 --- !u!114 &8700169133995922697
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -511,8 +480,13 @@ MonoBehaviour:
   healthChanged: {fileID: 0}
   onDeath: {fileID: 11400000, guid: 414dfc9853bd0654daa1e3928b01376e, type: 2}
   damageSourceTags: 00000000
+  maxHealth: 0
   hitPoints: 30
   isPlayer: 0
+  model: {fileID: 0}
+  additionalDashIFrame: 0
+  hitInvulnDurationSeconds: 0
+  invulnDeltaTime: 0
 --- !u!114 &7964350986800119521
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -761,8 +735,13 @@ MonoBehaviour:
   healthChanged: {fileID: 0}
   onDeath: {fileID: 11400000, guid: 414dfc9853bd0654daa1e3928b01376e, type: 2}
   damageSourceTags: 00000000
+  maxHealth: 0
   hitPoints: 5
   isPlayer: 0
+  model: {fileID: 0}
+  additionalDashIFrame: 0
+  hitInvulnDurationSeconds: 0
+  invulnDeltaTime: 0
 --- !u!114 &45415057789879407
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -1060,8 +1039,13 @@ MonoBehaviour:
   healthChanged: {fileID: 0}
   onDeath: {fileID: 11400000, guid: 414dfc9853bd0654daa1e3928b01376e, type: 2}
   damageSourceTags: 00000000
+  maxHealth: 0
   hitPoints: 5
   isPlayer: 0
+  model: {fileID: 0}
+  additionalDashIFrame: 0
+  hitInvulnDurationSeconds: 0
+  invulnDeltaTime: 0
 --- !u!114 &3894808808416603480
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -1297,8 +1281,13 @@ MonoBehaviour:
   healthChanged: {fileID: 0}
   onDeath: {fileID: 11400000, guid: 414dfc9853bd0654daa1e3928b01376e, type: 2}
   damageSourceTags: 00000000
+  maxHealth: 0
   hitPoints: 5
   isPlayer: 0
+  model: {fileID: 0}
+  additionalDashIFrame: 0
+  hitInvulnDurationSeconds: 0
+  invulnDeltaTime: 0
 --- !u!114 &1916220338556616545
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -1534,8 +1523,13 @@ MonoBehaviour:
   healthChanged: {fileID: 0}
   onDeath: {fileID: 11400000, guid: 414dfc9853bd0654daa1e3928b01376e, type: 2}
   damageSourceTags: 00000000
+  maxHealth: 0
   hitPoints: 5
   isPlayer: 0
+  model: {fileID: 0}
+  additionalDashIFrame: 0
+  hitInvulnDurationSeconds: 0
+  invulnDeltaTime: 0
 --- !u!114 &4412569622401324645
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -1895,8 +1889,13 @@ MonoBehaviour:
   healthChanged: {fileID: 0}
   onDeath: {fileID: 11400000, guid: 414dfc9853bd0654daa1e3928b01376e, type: 2}
   damageSourceTags: 00000000
+  maxHealth: 0
   hitPoints: 5
   isPlayer: 0
+  model: {fileID: 0}
+  additionalDashIFrame: 0
+  hitInvulnDurationSeconds: 0
+  invulnDeltaTime: 0
 --- !u!114 &4879755218026747470
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -2132,8 +2131,13 @@ MonoBehaviour:
   healthChanged: {fileID: 0}
   onDeath: {fileID: 11400000, guid: 414dfc9853bd0654daa1e3928b01376e, type: 2}
   damageSourceTags: 00000000
+  maxHealth: 0
   hitPoints: 5
   isPlayer: 0
+  model: {fileID: 0}
+  additionalDashIFrame: 0
+  hitInvulnDurationSeconds: 0
+  invulnDeltaTime: 0
 --- !u!114 &281822391758712190
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -2369,8 +2373,13 @@ MonoBehaviour:
   healthChanged: {fileID: 0}
   onDeath: {fileID: 11400000, guid: 414dfc9853bd0654daa1e3928b01376e, type: 2}
   damageSourceTags: 00000000
+  maxHealth: 0
   hitPoints: 5
   isPlayer: 0
+  model: {fileID: 0}
+  additionalDashIFrame: 0
+  hitInvulnDurationSeconds: 0
+  invulnDeltaTime: 0
 --- !u!114 &1160393979894556888
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/Sparrow/Assets/Prefabs/KrakenBoss/Kraken3.prefab
+++ b/Sparrow/Assets/Prefabs/KrakenBoss/Kraken3.prefab
@@ -111,8 +111,13 @@ MonoBehaviour:
   healthChanged: {fileID: 0}
   onDeath: {fileID: 11400000, guid: 414dfc9853bd0654daa1e3928b01376e, type: 2}
   damageSourceTags: 00000000
+  maxHealth: 0
   hitPoints: 5
   isPlayer: 0
+  model: {fileID: 0}
+  additionalDashIFrame: 0
+  hitInvulnDurationSeconds: 0
+  invulnDeltaTime: 0
 --- !u!1 &250386920661646367
 GameObject:
   m_ObjectHideFlags: 0
@@ -378,8 +383,13 @@ MonoBehaviour:
   healthChanged: {fileID: 0}
   onDeath: {fileID: 11400000, guid: 414dfc9853bd0654daa1e3928b01376e, type: 2}
   damageSourceTags: 00000000
+  maxHealth: 0
   hitPoints: 5
   isPlayer: 0
+  model: {fileID: 0}
+  additionalDashIFrame: 0
+  hitInvulnDurationSeconds: 0
+  invulnDeltaTime: 0
 --- !u!114 &6337516722564690523
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -424,7 +434,6 @@ GameObject:
   - component: {fileID: 6998928770152645900}
   - component: {fileID: 4678754082690815350}
   - component: {fileID: 8689071490316621584}
-  - component: {fileID: 2858533961949176842}
   - component: {fileID: 8700169133995922697}
   - component: {fileID: 3030936961560080983}
   - component: {fileID: 990925306226565462}
@@ -575,41 +584,6 @@ CapsuleCollider2D:
   m_Offset: {x: 0, y: 0}
   m_Size: {x: 5, y: 6}
   m_Direction: 0
---- !u!58 &2858533961949176842
-CircleCollider2D:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1011234398079243751}
-  m_Enabled: 1
-  m_Density: 1
-  m_Material: {fileID: 0}
-  m_IncludeLayers:
-    serializedVersion: 2
-    m_Bits: 0
-  m_ExcludeLayers:
-    serializedVersion: 2
-    m_Bits: 0
-  m_LayerOverridePriority: 0
-  m_ForceSendLayers:
-    serializedVersion: 2
-    m_Bits: 4294967295
-  m_ForceReceiveLayers:
-    serializedVersion: 2
-    m_Bits: 4294967295
-  m_ContactCaptureLayers:
-    serializedVersion: 2
-    m_Bits: 4294967295
-  m_CallbackLayers:
-    serializedVersion: 2
-    m_Bits: 4294967295
-  m_IsTrigger: 1
-  m_UsedByEffector: 0
-  m_UsedByComposite: 0
-  m_Offset: {x: 0, y: 0}
-  serializedVersion: 2
-  m_Radius: 3
 --- !u!114 &8700169133995922697
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -625,8 +599,13 @@ MonoBehaviour:
   healthChanged: {fileID: 0}
   onDeath: {fileID: 11400000, guid: 414dfc9853bd0654daa1e3928b01376e, type: 2}
   damageSourceTags: 00000000
+  maxHealth: 0
   hitPoints: 30
   isPlayer: 0
+  model: {fileID: 0}
+  additionalDashIFrame: 0
+  hitInvulnDurationSeconds: 0
+  invulnDeltaTime: 0
 --- !u!114 &3030936961560080983
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -877,8 +856,13 @@ MonoBehaviour:
   healthChanged: {fileID: 0}
   onDeath: {fileID: 11400000, guid: 414dfc9853bd0654daa1e3928b01376e, type: 2}
   damageSourceTags: 00000000
+  maxHealth: 0
   hitPoints: 5
   isPlayer: 0
+  model: {fileID: 0}
+  additionalDashIFrame: 0
+  hitInvulnDurationSeconds: 0
+  invulnDeltaTime: 0
 --- !u!114 &45415057789879407
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -1176,8 +1160,13 @@ MonoBehaviour:
   healthChanged: {fileID: 0}
   onDeath: {fileID: 11400000, guid: 414dfc9853bd0654daa1e3928b01376e, type: 2}
   damageSourceTags: 00000000
+  maxHealth: 0
   hitPoints: 5
   isPlayer: 0
+  model: {fileID: 0}
+  additionalDashIFrame: 0
+  hitInvulnDurationSeconds: 0
+  invulnDeltaTime: 0
 --- !u!114 &3894808808416603480
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -1413,8 +1402,13 @@ MonoBehaviour:
   healthChanged: {fileID: 0}
   onDeath: {fileID: 11400000, guid: 414dfc9853bd0654daa1e3928b01376e, type: 2}
   damageSourceTags: 00000000
+  maxHealth: 0
   hitPoints: 5
   isPlayer: 0
+  model: {fileID: 0}
+  additionalDashIFrame: 0
+  hitInvulnDurationSeconds: 0
+  invulnDeltaTime: 0
 --- !u!114 &1916220338556616545
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -1650,8 +1644,13 @@ MonoBehaviour:
   healthChanged: {fileID: 0}
   onDeath: {fileID: 11400000, guid: 414dfc9853bd0654daa1e3928b01376e, type: 2}
   damageSourceTags: 00000000
+  maxHealth: 0
   hitPoints: 5
   isPlayer: 0
+  model: {fileID: 0}
+  additionalDashIFrame: 0
+  hitInvulnDurationSeconds: 0
+  invulnDeltaTime: 0
 --- !u!114 &4412569622401324645
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -2011,8 +2010,13 @@ MonoBehaviour:
   healthChanged: {fileID: 0}
   onDeath: {fileID: 11400000, guid: 414dfc9853bd0654daa1e3928b01376e, type: 2}
   damageSourceTags: 00000000
+  maxHealth: 0
   hitPoints: 5
   isPlayer: 0
+  model: {fileID: 0}
+  additionalDashIFrame: 0
+  hitInvulnDurationSeconds: 0
+  invulnDeltaTime: 0
 --- !u!114 &4879755218026747470
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -2248,8 +2252,13 @@ MonoBehaviour:
   healthChanged: {fileID: 0}
   onDeath: {fileID: 11400000, guid: 414dfc9853bd0654daa1e3928b01376e, type: 2}
   damageSourceTags: 00000000
+  maxHealth: 0
   hitPoints: 5
   isPlayer: 0
+  model: {fileID: 0}
+  additionalDashIFrame: 0
+  hitInvulnDurationSeconds: 0
+  invulnDeltaTime: 0
 --- !u!114 &281822391758712190
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -2485,8 +2494,13 @@ MonoBehaviour:
   healthChanged: {fileID: 0}
   onDeath: {fileID: 11400000, guid: 414dfc9853bd0654daa1e3928b01376e, type: 2}
   damageSourceTags: 00000000
+  maxHealth: 0
   hitPoints: 5
   isPlayer: 0
+  model: {fileID: 0}
+  additionalDashIFrame: 0
+  hitInvulnDurationSeconds: 0
+  invulnDeltaTime: 0
 --- !u!114 &1160393979894556888
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/Sparrow/Assets/Prefabs/KrakenBoss/KrakenBarrel.prefab
+++ b/Sparrow/Assets/Prefabs/KrakenBoss/KrakenBarrel.prefab
@@ -1566,7 +1566,6 @@ GameObject:
   - component: {fileID: 7930680965863193927}
   - component: {fileID: 5779444652730490323}
   - component: {fileID: 37561852126863327}
-  - component: {fileID: 3976620816633983205}
   - component: {fileID: 7164335495317329830}
   - component: {fileID: 5677997009656851762}
   - component: {fileID: 3377210559871924644}
@@ -1714,41 +1713,6 @@ CapsuleCollider2D:
   m_Offset: {x: 0, y: 0}
   m_Size: {x: 6.59, y: 7.7}
   m_Direction: 0
---- !u!58 &3976620816633983205
-CircleCollider2D:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 7755128683342313001}
-  m_Enabled: 1
-  m_Density: 1
-  m_Material: {fileID: 0}
-  m_IncludeLayers:
-    serializedVersion: 2
-    m_Bits: 0
-  m_ExcludeLayers:
-    serializedVersion: 2
-    m_Bits: 0
-  m_LayerOverridePriority: 0
-  m_ForceSendLayers:
-    serializedVersion: 2
-    m_Bits: 4294967295
-  m_ForceReceiveLayers:
-    serializedVersion: 2
-    m_Bits: 4294967295
-  m_ContactCaptureLayers:
-    serializedVersion: 2
-    m_Bits: 4294967295
-  m_CallbackLayers:
-    serializedVersion: 2
-    m_Bits: 4294967295
-  m_IsTrigger: 1
-  m_UsedByEffector: 0
-  m_UsedByComposite: 0
-  m_Offset: {x: 0, y: 0}
-  serializedVersion: 2
-  m_Radius: 4.4
 --- !u!114 &7164335495317329830
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/Sparrow/Assets/Prefabs/KrakenBoss/KrakenCannon.prefab
+++ b/Sparrow/Assets/Prefabs/KrakenBoss/KrakenCannon.prefab
@@ -1566,7 +1566,6 @@ GameObject:
   - component: {fileID: 7930680965863193927}
   - component: {fileID: 5779444652730490323}
   - component: {fileID: 37561852126863327}
-  - component: {fileID: 3976620816633983205}
   - component: {fileID: 7164335495317329830}
   - component: {fileID: 5677997009656851762}
   m_Layer: 8
@@ -1713,41 +1712,6 @@ CapsuleCollider2D:
   m_Offset: {x: 0, y: 0}
   m_Size: {x: 3.02, y: 5.3}
   m_Direction: 0
---- !u!58 &3976620816633983205
-CircleCollider2D:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 7755128683342313001}
-  m_Enabled: 1
-  m_Density: 1
-  m_Material: {fileID: 0}
-  m_IncludeLayers:
-    serializedVersion: 2
-    m_Bits: 0
-  m_ExcludeLayers:
-    serializedVersion: 2
-    m_Bits: 0
-  m_LayerOverridePriority: 0
-  m_ForceSendLayers:
-    serializedVersion: 2
-    m_Bits: 4294967295
-  m_ForceReceiveLayers:
-    serializedVersion: 2
-    m_Bits: 4294967295
-  m_ContactCaptureLayers:
-    serializedVersion: 2
-    m_Bits: 4294967295
-  m_CallbackLayers:
-    serializedVersion: 2
-    m_Bits: 4294967295
-  m_IsTrigger: 1
-  m_UsedByEffector: 0
-  m_UsedByComposite: 0
-  m_Offset: {x: 0, y: 0}
-  serializedVersion: 2
-  m_Radius: 3.5
 --- !u!114 &7164335495317329830
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/Sparrow/Assets/Prefabs/KrakenBoss/TentacleCannonPrefab.prefab
+++ b/Sparrow/Assets/Prefabs/KrakenBoss/TentacleCannonPrefab.prefab
@@ -12,7 +12,6 @@ GameObject:
   - component: {fileID: 8135175822143399236}
   - component: {fileID: -7801349114137960917}
   - component: {fileID: -5095724165131227897}
-  - component: {fileID: -1302857460594714932}
   - component: {fileID: -2910938558028449925}
   - component: {fileID: 5461709906190230059}
   - component: {fileID: -8965846186406707897}
@@ -154,41 +153,6 @@ CapsuleCollider2D:
   m_Offset: {x: 0, y: 0}
   m_Size: {x: 3, y: 3}
   m_Direction: 0
---- !u!58 &-1302857460594714932
-CircleCollider2D:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 135509283537529223}
-  m_Enabled: 1
-  m_Density: 1
-  m_Material: {fileID: 0}
-  m_IncludeLayers:
-    serializedVersion: 2
-    m_Bits: 0
-  m_ExcludeLayers:
-    serializedVersion: 2
-    m_Bits: 0
-  m_LayerOverridePriority: 0
-  m_ForceSendLayers:
-    serializedVersion: 2
-    m_Bits: 4294967295
-  m_ForceReceiveLayers:
-    serializedVersion: 2
-    m_Bits: 4294967295
-  m_ContactCaptureLayers:
-    serializedVersion: 2
-    m_Bits: 4294967295
-  m_CallbackLayers:
-    serializedVersion: 2
-    m_Bits: 4294967295
-  m_IsTrigger: 1
-  m_UsedByEffector: 0
-  m_UsedByComposite: 0
-  m_Offset: {x: 0, y: 0}
-  serializedVersion: 2
-  m_Radius: 2
 --- !u!114 &-2910938558028449925
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -208,6 +172,7 @@ MonoBehaviour:
   hitPoints: 5
   isPlayer: 0
   model: {fileID: 135509283537529223}
+  additionalDashIFrame: 0
   hitInvulnDurationSeconds: 0
   invulnDeltaTime: 0
 --- !u!114 &5461709906190230059

--- a/Sparrow/Assets/Prefabs/KrakenBoss/TentacleR.prefab
+++ b/Sparrow/Assets/Prefabs/KrakenBoss/TentacleR.prefab
@@ -12,7 +12,6 @@ GameObject:
   - component: {fileID: 1967662949920922427}
   - component: {fileID: 7209846477368653438}
   - component: {fileID: 3825436788023796077}
-  - component: {fileID: 2644779676416397477}
   - component: {fileID: 5724945622929543249}
   - component: {fileID: -1310329126172400587}
   - component: {fileID: 8023703662039456121}
@@ -154,41 +153,6 @@ CapsuleCollider2D:
   m_Offset: {x: 0, y: 0}
   m_Size: {x: 2.25, y: 5.21875}
   m_Direction: 0
---- !u!58 &2644779676416397477
-CircleCollider2D:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2811579824418986743}
-  m_Enabled: 1
-  m_Density: 1
-  m_Material: {fileID: 0}
-  m_IncludeLayers:
-    serializedVersion: 2
-    m_Bits: 0
-  m_ExcludeLayers:
-    serializedVersion: 2
-    m_Bits: 0
-  m_LayerOverridePriority: 0
-  m_ForceSendLayers:
-    serializedVersion: 2
-    m_Bits: 4294967295
-  m_ForceReceiveLayers:
-    serializedVersion: 2
-    m_Bits: 4294967295
-  m_ContactCaptureLayers:
-    serializedVersion: 2
-    m_Bits: 4294967295
-  m_CallbackLayers:
-    serializedVersion: 2
-    m_Bits: 4294967295
-  m_IsTrigger: 1
-  m_UsedByEffector: 0
-  m_UsedByComposite: 0
-  m_Offset: {x: 0, y: 0}
-  serializedVersion: 2
-  m_Radius: 2.609375
 --- !u!114 &5724945622929543249
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -204,8 +168,13 @@ MonoBehaviour:
   healthChanged: {fileID: 0}
   onDeath: {fileID: 11400000, guid: 414dfc9853bd0654daa1e3928b01376e, type: 2}
   damageSourceTags: 00000000
+  maxHealth: 0
   hitPoints: 5
   isPlayer: 0
+  model: {fileID: 0}
+  additionalDashIFrame: 0
+  hitInvulnDurationSeconds: 0
+  invulnDeltaTime: 0
 --- !u!114 &-1310329126172400587
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/Sparrow/Assets/Prefabs/KrakenBoss/body_redD.prefab
+++ b/Sparrow/Assets/Prefabs/KrakenBoss/body_redD.prefab
@@ -43,7 +43,6 @@ GameObject:
   - component: {fileID: 6998928770152645900}
   - component: {fileID: 4678754082690815350}
   - component: {fileID: 8689071490316621584}
-  - component: {fileID: 2858533961949176842}
   - component: {fileID: 8700169133995922697}
   - component: {fileID: 7964350986800119521}
   - component: {fileID: 3030936961560080983}
@@ -193,41 +192,6 @@ CapsuleCollider2D:
   m_Offset: {x: 0, y: 0}
   m_Size: {x: 4.63, y: 5.8}
   m_Direction: 0
---- !u!58 &2858533961949176842
-CircleCollider2D:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1011234398079243751}
-  m_Enabled: 1
-  m_Density: 1
-  m_Material: {fileID: 0}
-  m_IncludeLayers:
-    serializedVersion: 2
-    m_Bits: 0
-  m_ExcludeLayers:
-    serializedVersion: 2
-    m_Bits: 0
-  m_LayerOverridePriority: 0
-  m_ForceSendLayers:
-    serializedVersion: 2
-    m_Bits: 4294967295
-  m_ForceReceiveLayers:
-    serializedVersion: 2
-    m_Bits: 4294967295
-  m_ContactCaptureLayers:
-    serializedVersion: 2
-    m_Bits: 4294967295
-  m_CallbackLayers:
-    serializedVersion: 2
-    m_Bits: 4294967295
-  m_IsTrigger: 1
-  m_UsedByEffector: 0
-  m_UsedByComposite: 0
-  m_Offset: {x: 0, y: 0}
-  serializedVersion: 2
-  m_Radius: 3
 --- !u!114 &8700169133995922697
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -243,8 +207,13 @@ MonoBehaviour:
   healthChanged: {fileID: 0}
   onDeath: {fileID: 11400000, guid: 414dfc9853bd0654daa1e3928b01376e, type: 2}
   damageSourceTags: 00000000
+  maxHealth: 0
   hitPoints: 100
   isPlayer: 0
+  model: {fileID: 0}
+  additionalDashIFrame: 0
+  hitInvulnDurationSeconds: 0
+  invulnDeltaTime: 0
 --- !u!114 &7964350986800119521
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/Sparrow/Assets/Prefabs/TurretEnemies/BarrelTurret.prefab
+++ b/Sparrow/Assets/Prefabs/TurretEnemies/BarrelTurret.prefab
@@ -12,7 +12,6 @@ GameObject:
   - component: {fileID: 6316852848907664970}
   - component: {fileID: 3444548532711474865}
   - component: {fileID: 3121054435756799427}
-  - component: {fileID: 6068696649609005393}
   - component: {fileID: 5949667790845223335}
   - component: {fileID: 3162489764259306103}
   - component: {fileID: 4181543629081529207}
@@ -153,41 +152,6 @@ CapsuleCollider2D:
   m_Offset: {x: 0, y: 0}
   m_Size: {x: 1.5, y: 1.5}
   m_Direction: 1
---- !u!58 &6068696649609005393
-CircleCollider2D:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1795344308091871500}
-  m_Enabled: 1
-  m_Density: 1
-  m_Material: {fileID: 0}
-  m_IncludeLayers:
-    serializedVersion: 2
-    m_Bits: 0
-  m_ExcludeLayers:
-    serializedVersion: 2
-    m_Bits: 0
-  m_LayerOverridePriority: 0
-  m_ForceSendLayers:
-    serializedVersion: 2
-    m_Bits: 4294967295
-  m_ForceReceiveLayers:
-    serializedVersion: 2
-    m_Bits: 4294967295
-  m_ContactCaptureLayers:
-    serializedVersion: 2
-    m_Bits: 4294967295
-  m_CallbackLayers:
-    serializedVersion: 2
-    m_Bits: 4294967295
-  m_IsTrigger: 1
-  m_UsedByEffector: 0
-  m_UsedByComposite: 0
-  m_Offset: {x: 0, y: 0}
-  serializedVersion: 2
-  m_Radius: 0.85
 --- !u!114 &5949667790845223335
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -253,9 +217,10 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 2017273588473969250}
+  - component: {fileID: 569714240809982264}
   m_Layer: 8
   m_Name: TurretPoint
-  m_TagString: Enemy
+  m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
@@ -269,9 +234,44 @@ Transform:
   m_GameObject: {fileID: 9029002704721577383}
   serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0.139, z: 0}
+  m_LocalPosition: {x: -0.003, y: 0.008, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 3494607317772048625}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!58 &569714240809982264
+CircleCollider2D:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 9029002704721577383}
+  m_Enabled: 1
+  m_Density: 1
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_ForceSendLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_ForceReceiveLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_ContactCaptureLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_CallbackLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_IsTrigger: 1
+  m_UsedByEffector: 0
+  m_UsedByComposite: 0
+  m_Offset: {x: 0, y: 0}
+  serializedVersion: 2
+  m_Radius: 0.5

--- a/Sparrow/Assets/Scenes/Menus/Credits.unity
+++ b/Sparrow/Assets/Scenes/Menus/Credits.unity
@@ -1067,7 +1067,8 @@ MonoBehaviour:
       m_Calls: []
   m_text: "Bryan Yee\n\nCole Ritmire\n\tUI/UX designer\n\tLead Game Designer\n\tSystem
     Analyst\n\tJunior Coding Extraordinaire\n\nJacob Robbins\n\nKeith Miller - mkm2010@gmail.com\n\tLead
-    System Designer\n\nMichael Prather\n\tSystem Designer\n\nNick Khan"
+    System Designer\n\tUnity Tutorial Googling Expert\n\nMichael Prather\n\tSystem
+    Designer\n\nNick Khan"
   m_isRightToLeft: 0
   m_fontAsset: {fileID: 11400000, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
   m_sharedMaterial: {fileID: 2180264, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}

--- a/Sparrow/Assets/Scripts/GameState/HealthManager.cs
+++ b/Sparrow/Assets/Scripts/GameState/HealthManager.cs
@@ -75,6 +75,8 @@ public class HealthManager : MonoBehaviour
     }
     public void ApplyDamage(float damageAmount, DamageSourceTag damageSourceTag)
     {
+        if (isInvuln) return; // Handle case where explosion applies direct damage
+
         hitPoints -= Mathf.RoundToInt(damageAmount); // Assuming damage is an integer
         if (healthChanged != null)
         {

--- a/Sparrow/Assets/Scripts/Player/ShipConfiguration.cs
+++ b/Sparrow/Assets/Scripts/Player/ShipConfiguration.cs
@@ -43,9 +43,9 @@ public class ShipConfiguration : MonoBehaviour
         if (gameObject.CompareTag("Player"))
         {
             GlobalVariables.Set(PLAYER_CANNON_DEF, cannonDefs);
+            CircleCollider2D _autoTargetCollider = gameObject.GetComponent<CircleCollider2D>();
+            _autoTargetCollider.radius = _maxDistance - 0.05f; // a little wiggle room so that we don't auto-target things just on the edge of range
         }
-        CircleCollider2D _autoTargetCollider = gameObject.GetComponent<CircleCollider2D>();
-        _autoTargetCollider.radius = _maxDistance - 0.05f; // a little wiggle room so that we don't auto-target things just on the edge of range
     }
 
     public void UpdateCannonTarget(GameObject target)


### PR DESCRIPTION
1. Fixing bug where player auto target was picking up collision with the enemy auto-target range collider. Removed all enemy ship auto-target circle colliders.
2. Add isInvuln check into ApplyDamage function of HealthManager for when explosion (or any other type of attacks) try to deal damage directly to player